### PR TITLE
RELATED: RAIL-3998 migrate older versions to the new DocSearch

### DIFF
--- a/v8.5.0/docs/index.html
+++ b/v8.5.0/docs/index.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
+++ b/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror.cause.html
+++ b/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror.html
+++ b/v8.5.0/docs/sdk-backend-spi.analyticalbackenderror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.analyticalbackenderrortypes.html
+++ b/v8.5.0/docs/sdk-backend-spi.analyticalbackenderrortypes.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.analyticalbackendfactory.html
+++ b/v8.5.0/docs/sdk-backend-spi.analyticalbackendfactory.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.attributedescriptorlocalid.html
+++ b/v8.5.0/docs/sdk-backend-spi.attributedescriptorlocalid.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.attributedescriptorname.html
+++ b/v8.5.0/docs/sdk-backend-spi.attributedescriptorname.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.authenticationflow.html
+++ b/v8.5.0/docs/sdk-backend-spi.authenticationflow.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.catalogitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.catalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.catalogitemmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.catalogitemmetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.catalogitemtype.html
+++ b/v8.5.0/docs/sdk-backend-spi.catalogitemtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.datacolumntype.html
+++ b/v8.5.0/docs/sdk-backend-spi.datacolumntype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.datasetloadstatus.html
+++ b/v8.5.0/docs/sdk-backend-spi.datasetloadstatus.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.datatoolargeerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.datatoolargeerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.datavalue.html
+++ b/v8.5.0/docs/sdk-backend-spi.datavalue.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.errorconverter.html
+++ b/v8.5.0/docs/sdk-backend-spi.errorconverter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.groupablecatalogitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.groupablecatalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.html
+++ b/v8.5.0/docs/sdk-backend-spi.html
@@ -284,7 +284,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.config.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.organization.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.organization.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalbackendconfig.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalbackendconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.users.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.users.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelement.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelement.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelement.title.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelement.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelement.uri.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelement.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.iattributemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticatedprincipal.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticatedprincipal.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationcontext.backend.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationcontext.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationcontext.client.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationcontext.client.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationcontext.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationcontext.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
+++ b/v8.5.0/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.html
@@ -102,7 +102,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
+++ b/v8.5.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogattribute.attribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogattribute.displayforms.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogattribute.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogattribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogattribute.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogattribute.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogattribute.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdateattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogdatedataset.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogfact.fact.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogfact.fact.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogfact.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogfact.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogfact.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icataloggroup.html
+++ b/v8.5.0/docs/sdk-backend-spi.icataloggroup.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icataloggroup.tag.html
+++ b/v8.5.0/docs/sdk-backend-spi.icataloggroup.tag.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icataloggroup.title.html
+++ b/v8.5.0/docs/sdk-backend-spi.icataloggroup.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogitembase.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogitembase.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogitembase.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogitembase.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogmeasure.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogmeasure.measure.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogmeasure.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.icatalogmeasure.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.icatalogmeasure.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idashboardmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.idashboardmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idashboardmetadataobject.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.idashboardmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatacolumn.column.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatacolumn.column.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatacolumn.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatacolumn.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataheader.columns.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataheader.columns.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataheader.headerrowindex.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataheader.headerrowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataset.dataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataset.dataset.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataset.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.created.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.created.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.owner.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.owner.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.status.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetloadinfo.status.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetmetadataobject.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetuser.fullname.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetuser.fullname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetuser.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatasetuser.login.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatasetuser.login.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.count.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.data.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.data.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.definition.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.equals.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.fingerprint.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.headeritems.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.headeritems.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.offset.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.result.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.result.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.totalcount.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.totalcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.totals.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.totals.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idataview.warnings.html
+++ b/v8.5.0/docs/sdk-backend-spi.idataview.warnings.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idimensiondescriptor.headers.html
+++ b/v8.5.0/docs/sdk-backend-spi.idimensiondescriptor.headers.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idimensiondescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.idimensiondescriptor.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.idimensionitemdescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.idimensionitemdescriptor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.query.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.withlimit.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.withmeasures.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.withmeasures.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.withoffset.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsquery.withoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryattributefilter.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryattributefilter.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryfactory.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryfactory.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.order.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.order.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ielementsqueryresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.ielementsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
@@ -36,7 +36,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.foritems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.foritems.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionfactory.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.definition.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.dimensions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.dimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.equals.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.export.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.export.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.readall.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.readall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.readwindow.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.readwindow.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexecutionresult.transform.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexecutionresult.transform.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportconfig.format.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportconfig.format.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportconfig.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportconfig.showfilters.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportconfig.showfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportconfig.title.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportconfig.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iexportresult.uri.html
+++ b/v8.5.0/docs/sdk-backend-spi.iexportresult.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ifactmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.ifactmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ifactmetadataobject.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.ifactmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
+++ b/v8.5.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
+++ b/v8.5.0/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.igroupablecatalogitembase.html
+++ b/v8.5.0/docs/sdk-backend-spi.igroupablecatalogitembase.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightreferences.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightreferences.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightreferencing.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightreferencing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iinsightsqueryresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.iinsightsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasuredescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasuredescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasureexpressiontoken.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasureexpressiontoken.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasuregroupdescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasuregroupdescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasuremetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasuremetadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
+++ b/v8.5.0/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.imetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.imetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.insightordering.html
+++ b/v8.5.0/docs/sdk-backend-spi.insightordering.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.insightreferencetypes.html
+++ b/v8.5.0/docs/sdk-backend-spi.insightreferencetypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.html
+++ b/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
+++ b/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
+++ b/v8.5.0/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganization.getdescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganization.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganization.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganization.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganization.organizationid.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganization.organizationid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganization.securitysettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganization.securitysettings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganizationdescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganizationdescriptor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganizationdescriptor.id.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganizationdescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganizationdescriptor.title.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganizationdescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iorganizations.html
+++ b/v8.5.0/docs/sdk-backend-spi.iorganizations.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipagedresource.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipagedresource.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipagedresource.items.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipagedresource.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipagedresource.limit.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipagedresource.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipagedresource.next.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipagedresource.next.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipagedresource.offset.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipagedresource.offset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipagedresource.totalcount.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipagedresource.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.definition.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.equals.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.execute.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.execute.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
+++ b/v8.5.0/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultattributeheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultattributeheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultheader.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultmeasureheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultmeasureheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresulttotalheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresulttotalheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultwarning.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultwarning.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultwarning.message.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultwarning.message.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultwarning.parameters.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultwarning.parameters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iresultwarning.warningcode.html
+++ b/v8.5.0/docs/sdk-backend-spi.iresultwarning.warningcode.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isanalyticalbackenderror.html
+++ b/v8.5.0/docs/sdk-backend-spi.isanalyticalbackenderror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isattributedescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.isattributedescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isattributemetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.isattributemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iscatalogattribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.iscatalogattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iscatalogdatedataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.iscatalogdatedataset.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iscatalogfact.html
+++ b/v8.5.0/docs/sdk-backend-spi.iscatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iscatalogmeasure.html
+++ b/v8.5.0/docs/sdk-backend-spi.iscatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isdashboardmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.isdashboardmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isdatasetmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.isdatasetmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isdatatoolargeerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.isdatatoolargeerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isecuritysettingsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.isecuritysettingsservice.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
+++ b/v8.5.0/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
+++ b/v8.5.0/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iseparators.decimal.html
+++ b/v8.5.0/docs/sdk-backend-spi.iseparators.decimal.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iseparators.html
+++ b/v8.5.0/docs/sdk-backend-spi.iseparators.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iseparators.thousand.html
+++ b/v8.5.0/docs/sdk-backend-spi.iseparators.thousand.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enableapproxcount.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enableapproxcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablebulletchart.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablebulletchart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enabledatasampling.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enabledatasampling.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekdzooming.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekdzooming.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablemultipledates.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablemultipledates.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enablesectionheaders.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enablesectionheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.enableweekfilters.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.enableweekfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.html
@@ -110,7 +110,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
+++ b/v8.5.0/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isfactmetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.isfactmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ismeasuredescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ismeasuredescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ismeasuremetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.ismeasuremetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
+++ b/v8.5.0/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ismetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.ismetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isnodataerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.isnodataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isnotauthenticated.html
+++ b/v8.5.0/docs/sdk-backend-spi.isnotauthenticated.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isnotimplemented.html
+++ b/v8.5.0/docs/sdk-backend-spi.isnotimplemented.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isnotsupported.html
+++ b/v8.5.0/docs/sdk-backend-spi.isnotsupported.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isprotecteddataerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.isprotecteddataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isresultattributeheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.isresultattributeheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isresultmeasureheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.isresultmeasureheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isresulttotalheader.html
+++ b/v8.5.0/docs/sdk-backend-spi.isresulttotalheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.istotaldescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.istotaldescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isunexpectederror.html
+++ b/v8.5.0/docs/sdk-backend-spi.isunexpectederror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isunexpectedresponseerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.isunexpectedresponseerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.isvariablemetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.isvariablemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itextexpressiontoken.html
+++ b/v8.5.0/docs/sdk-backend-spi.itextexpressiontoken.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itextexpressiontoken.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.itextexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itextexpressiontoken.value.html
+++ b/v8.5.0/docs/sdk-backend-spi.itextexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.analyticaldesigner.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.analyticaldesigner.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.button.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.button.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.chart.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.chart.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.dashboards.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.dashboards.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.kpi.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.kpi.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.modal.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.modal.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.palette.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.palette.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.table.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.table.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.tooltip.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.tooltip.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itheme.typography.html
+++ b/v8.5.0/docs/sdk-backend-spi.itheme.typography.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.axiscolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.axiscolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.gridcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.base.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.base.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.dark.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.dark.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.light.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecolorfamily.light.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemecomplementarypalette.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemekpi.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemekpi.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemekpi.value.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemekpi.value.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.complementary.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.complementary.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.error.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.error.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.info.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.info.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.primary.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.primary.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.success.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.success.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemepalette.warning.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemepalette.warning.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.gridcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetable.valuecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetable.valuecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetypography.font.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetypography.font.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetypography.fontbold.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetypography.fontbold.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemetypography.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemetypography.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemewidgettitle.color.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemewidgettitle.color.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemewidgettitle.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemewidgettitle.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
+++ b/v8.5.0/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itotaldescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.itotaldescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
+++ b/v8.5.0/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iuserservice.getuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.iuserservice.getuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iuserservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iuserservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iuserservice.settings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iuserservice.settings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iusersettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iusersettings.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iusersettings.locale.html
+++ b/v8.5.0/docs/sdk-backend-spi.iusersettings.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iusersettings.separators.html
+++ b/v8.5.0/docs/sdk-backend-spi.iusersettings.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iusersettings.userid.html
+++ b/v8.5.0/docs/sdk-backend-spi.iusersettings.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iusersettingsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iusersettingsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iuserworkspacesettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iuserworkspacesettings.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ivariablemetadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.ivariablemetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.ivariablemetadataobject.type.html
+++ b/v8.5.0/docs/sdk-backend-spi.ivariablemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceattributesservice.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalog.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalog.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedatasetsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedatasetsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.description.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.id.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.title.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacedescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacefactsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacefactsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacepermissions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacepermissions.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacepermissionsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacepermissionsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesettings.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesettings.workspace.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesettings.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesettingsservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesettingsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.query.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.query.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryfactory.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryresult.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryresult.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryresult.search.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacesqueryresult.search.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspacestylingservice.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspacestylingservice.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.email.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.firstname.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.fullname.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.lastname.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.login.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.ref.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.uri.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceuser.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceusersquery.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceusersquery.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
+++ b/v8.5.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.metadataobject.html
+++ b/v8.5.0/docs/sdk-backend-spi.metadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.metadataobjectid.html
+++ b/v8.5.0/docs/sdk-backend-spi.metadataobjectid.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.nodataerror._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.nodataerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.nodataerror.dataview.html
+++ b/v8.5.0/docs/sdk-backend-spi.nodataerror.dataview.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.nodataerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.nodataerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notauthenticated._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.notauthenticated._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
+++ b/v8.5.0/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notauthenticated.html
+++ b/v8.5.0/docs/sdk-backend-spi.notauthenticated.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notauthenticatedhandler.html
+++ b/v8.5.0/docs/sdk-backend-spi.notauthenticatedhandler.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notimplemented._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.notimplemented._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notimplemented.html
+++ b/v8.5.0/docs/sdk-backend-spi.notimplemented.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notsupported._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.notsupported._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.notsupported.html
+++ b/v8.5.0/docs/sdk-backend-spi.notsupported.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.prepareexecution.html
+++ b/v8.5.0/docs/sdk-backend-spi.prepareexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.protecteddataerror._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.protecteddataerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.protecteddataerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.protecteddataerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.resultheadername.html
+++ b/v8.5.0/docs/sdk-backend-spi.resultheadername.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.supportedinsightreferencetypes.html
+++ b/v8.5.0/docs/sdk-backend-spi.supportedinsightreferencetypes.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.themecolor.html
+++ b/v8.5.0/docs/sdk-backend-spi.themecolor.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.themefonturi.html
+++ b/v8.5.0/docs/sdk-backend-spi.themefonturi.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.unexpectederror._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.unexpectederror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.unexpectederror.html
+++ b/v8.5.0/docs/sdk-backend-spi.unexpectederror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
+++ b/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror.html
+++ b/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
+++ b/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
+++ b/v8.5.0/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.validationcontext.html
+++ b/v8.5.0/docs/sdk-backend-spi.validationcontext.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-backend-spi.workspacepermission.html
+++ b/v8.5.0/docs/sdk-backend-spi.workspacepermission.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.absolutedatefiltervalues.html
+++ b/v8.5.0/docs/sdk-model.absolutedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.alltimegranularity.html
+++ b/v8.5.0/docs/sdk-model.alltimegranularity.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.anyattribute.html
+++ b/v8.5.0/docs/sdk-model.anyattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.anybucket.html
+++ b/v8.5.0/docs/sdk-model.anybucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.anymeasure.html
+++ b/v8.5.0/docs/sdk-model.anymeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.applyratiorule.html
+++ b/v8.5.0/docs/sdk-model.applyratiorule.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.areobjrefsequal.html
+++ b/v8.5.0/docs/sdk-model.areobjrefsequal.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.operands.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.operands.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.operator.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasurebuilder.operator.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasurebuilderinput.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.arithmeticmeasureoperator.html
+++ b/v8.5.0/docs/sdk-model.arithmeticmeasureoperator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributealias.html
+++ b/v8.5.0/docs/sdk-model.attributealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.alias.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.build.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.build.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.defaultlocalid.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.displayform.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.localid.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilder.noalias.html
+++ b/v8.5.0/docs/sdk-model.attributebuilder.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributebuilderinput.html
+++ b/v8.5.0/docs/sdk-model.attributebuilderinput.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributedisplayformref.html
+++ b/v8.5.0/docs/sdk-model.attributedisplayformref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributeidentifier.html
+++ b/v8.5.0/docs/sdk-model.attributeidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributeinbucket.html
+++ b/v8.5.0/docs/sdk-model.attributeinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributelocalid.html
+++ b/v8.5.0/docs/sdk-model.attributelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributelocatorelement.html
+++ b/v8.5.0/docs/sdk-model.attributelocatorelement.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributelocatoridentifier.html
+++ b/v8.5.0/docs/sdk-model.attributelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributemodifications.html
+++ b/v8.5.0/docs/sdk-model.attributemodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributepredicate.html
+++ b/v8.5.0/docs/sdk-model.attributepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributesfind.html
+++ b/v8.5.0/docs/sdk-model.attributesfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.attributeuri.html
+++ b/v8.5.0/docs/sdk-model.attributeuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketattribute.html
+++ b/v8.5.0/docs/sdk-model.bucketattribute.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketattributeindex.html
+++ b/v8.5.0/docs/sdk-model.bucketattributeindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketattributes.html
+++ b/v8.5.0/docs/sdk-model.bucketattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketisempty.html
+++ b/v8.5.0/docs/sdk-model.bucketisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketitemlocalid.html
+++ b/v8.5.0/docs/sdk-model.bucketitemlocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketitemmodifications.html
+++ b/v8.5.0/docs/sdk-model.bucketitemmodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketitemreduce.html
+++ b/v8.5.0/docs/sdk-model.bucketitemreduce.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketitemreducer.html
+++ b/v8.5.0/docs/sdk-model.bucketitemreducer.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketitems.html
+++ b/v8.5.0/docs/sdk-model.bucketitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketmeasure.html
+++ b/v8.5.0/docs/sdk-model.bucketmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketmeasureindex.html
+++ b/v8.5.0/docs/sdk-model.bucketmeasureindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketmeasures.html
+++ b/v8.5.0/docs/sdk-model.bucketmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketmodifyitems.html
+++ b/v8.5.0/docs/sdk-model.bucketmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketpredicate.html
+++ b/v8.5.0/docs/sdk-model.bucketpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsattributes.html
+++ b/v8.5.0/docs/sdk-model.bucketsattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsbyid.html
+++ b/v8.5.0/docs/sdk-model.bucketsbyid.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsettotals.html
+++ b/v8.5.0/docs/sdk-model.bucketsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsfind.html
+++ b/v8.5.0/docs/sdk-model.bucketsfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsfindattribute.html
+++ b/v8.5.0/docs/sdk-model.bucketsfindattribute.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsfindmeasure.html
+++ b/v8.5.0/docs/sdk-model.bucketsfindmeasure.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsisempty.html
+++ b/v8.5.0/docs/sdk-model.bucketsisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsitems.html
+++ b/v8.5.0/docs/sdk-model.bucketsitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsmeasures.html
+++ b/v8.5.0/docs/sdk-model.bucketsmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsmodifyitem.html
+++ b/v8.5.0/docs/sdk-model.bucketsmodifyitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketsreduceitem.html
+++ b/v8.5.0/docs/sdk-model.bucketsreduceitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.bucketstotals.html
+++ b/v8.5.0/docs/sdk-model.bucketstotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.buckettotals.html
+++ b/v8.5.0/docs/sdk-model.buckettotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.colorpaletteitemtorgb.html
+++ b/v8.5.0/docs/sdk-model.colorpaletteitemtorgb.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.colorpalettetocolors.html
+++ b/v8.5.0/docs/sdk-model.colorpalettetocolors.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.comparisonconditionoperator.html
+++ b/v8.5.0/docs/sdk-model.comparisonconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.computeratiorule.html
+++ b/v8.5.0/docs/sdk-model.computeratiorule.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dateattributegranularity.html
+++ b/v8.5.0/docs/sdk-model.dateattributegranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dategranularity.html
+++ b/v8.5.0/docs/sdk-model.dategranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defaultdimensionsgenerator.html
+++ b/v8.5.0/docs/sdk-model.defaultdimensionsgenerator.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.deffingerprint.html
+++ b/v8.5.0/docs/sdk-model.deffingerprint.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defsetdimensions.html
+++ b/v8.5.0/docs/sdk-model.defsetdimensions.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defsetexecconfig.html
+++ b/v8.5.0/docs/sdk-model.defsetexecconfig.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defsetpostprocessing.html
+++ b/v8.5.0/docs/sdk-model.defsetpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defsetsorts.html
+++ b/v8.5.0/docs/sdk-model.defsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.deftotals.html
+++ b/v8.5.0/docs/sdk-model.deftotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defwithdateformat.html
+++ b/v8.5.0/docs/sdk-model.defwithdateformat.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defwithdimensions.html
+++ b/v8.5.0/docs/sdk-model.defwithdimensions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defwithexecconfig.html
+++ b/v8.5.0/docs/sdk-model.defwithexecconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defwithfilters.html
+++ b/v8.5.0/docs/sdk-model.defwithfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defwithpostprocessing.html
+++ b/v8.5.0/docs/sdk-model.defwithpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.defwithsorting.html
+++ b/v8.5.0/docs/sdk-model.defwithsorting.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.deserializeobjref.html
+++ b/v8.5.0/docs/sdk-model.deserializeobjref.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dimensiongenerator.html
+++ b/v8.5.0/docs/sdk-model.dimensiongenerator.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dimensionitem.html
+++ b/v8.5.0/docs/sdk-model.dimensionitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dimensionsettotals.html
+++ b/v8.5.0/docs/sdk-model.dimensionsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dimensionsfinditem.html
+++ b/v8.5.0/docs/sdk-model.dimensionsfinditem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.dimensiontotals.html
+++ b/v8.5.0/docs/sdk-model.dimensiontotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.disablecomputeratio.html
+++ b/v8.5.0/docs/sdk-model.disablecomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.emptydef.html
+++ b/v8.5.0/docs/sdk-model.emptydef.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.factorynotationfor.html
+++ b/v8.5.0/docs/sdk-model.factorynotationfor.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.filterattributeelements.html
+++ b/v8.5.0/docs/sdk-model.filterattributeelements.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.filterattributeelements_1.html
+++ b/v8.5.0/docs/sdk-model.filterattributeelements_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.filterisempty.html
+++ b/v8.5.0/docs/sdk-model.filterisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.filtermeasureref.html
+++ b/v8.5.0/docs/sdk-model.filtermeasureref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.filterobjref.html
+++ b/v8.5.0/docs/sdk-model.filterobjref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.filterobjref_1.html
+++ b/v8.5.0/docs/sdk-model.filterobjref_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.guidtype.html
+++ b/v8.5.0/docs/sdk-model.guidtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.html
+++ b/v8.5.0/docs/sdk-model.html
@@ -427,7 +427,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
+++ b/v8.5.0/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iabsolutedatefilter.html
+++ b/v8.5.0/docs/sdk-model.iabsolutedatefilter.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iabsolutedatefiltervalues.from.html
+++ b/v8.5.0/docs/sdk-model.iabsolutedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iabsolutedatefiltervalues.html
+++ b/v8.5.0/docs/sdk-model.iabsolutedatefiltervalues.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iabsolutedatefiltervalues.to.html
+++ b/v8.5.0/docs/sdk-model.iabsolutedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
+++ b/v8.5.0/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iarithmeticmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.iarithmeticmeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattribute.attribute.html
+++ b/v8.5.0/docs/sdk-model.iattribute.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattribute.html
+++ b/v8.5.0/docs/sdk-model.iattribute.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributeelements.html
+++ b/v8.5.0/docs/sdk-model.iattributeelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributeelementsbyref.html
+++ b/v8.5.0/docs/sdk-model.iattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributeelementsbyref.uris.html
+++ b/v8.5.0/docs/sdk-model.iattributeelementsbyref.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributeelementsbyvalue.html
+++ b/v8.5.0/docs/sdk-model.iattributeelementsbyvalue.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributeelementsbyvalue.values.html
+++ b/v8.5.0/docs/sdk-model.iattributeelementsbyvalue.values.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributefilter.html
+++ b/v8.5.0/docs/sdk-model.iattributefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
+++ b/v8.5.0/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributelocatoritem.html
+++ b/v8.5.0/docs/sdk-model.iattributelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributeormeasure.html
+++ b/v8.5.0/docs/sdk-model.iattributeormeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributesortitem.attributesortitem.html
+++ b/v8.5.0/docs/sdk-model.iattributesortitem.attributesortitem.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iattributesortitem.html
+++ b/v8.5.0/docs/sdk-model.iattributesortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ibucket.html
+++ b/v8.5.0/docs/sdk-model.ibucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ibucket.items.html
+++ b/v8.5.0/docs/sdk-model.ibucket.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ibucket.localidentifier.html
+++ b/v8.5.0/docs/sdk-model.ibucket.localidentifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ibucket.totals.html
+++ b/v8.5.0/docs/sdk-model.ibucket.totals.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolor.html
+++ b/v8.5.0/docs/sdk-model.icolor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorfrompalette.html
+++ b/v8.5.0/docs/sdk-model.icolorfrompalette.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorfrompalette.type.html
+++ b/v8.5.0/docs/sdk-model.icolorfrompalette.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorfrompalette.value.html
+++ b/v8.5.0/docs/sdk-model.icolorfrompalette.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolormappingitem.color.html
+++ b/v8.5.0/docs/sdk-model.icolormappingitem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolormappingitem.html
+++ b/v8.5.0/docs/sdk-model.icolormappingitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolormappingitem.id.html
+++ b/v8.5.0/docs/sdk-model.icolormappingitem.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorpalette.html
+++ b/v8.5.0/docs/sdk-model.icolorpalette.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorpaletteitem.fill.html
+++ b/v8.5.0/docs/sdk-model.icolorpaletteitem.fill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorpaletteitem.guid.html
+++ b/v8.5.0/docs/sdk-model.icolorpaletteitem.guid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icolorpaletteitem.html
+++ b/v8.5.0/docs/sdk-model.icolorpaletteitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icomparisoncondition.comparison.html
+++ b/v8.5.0/docs/sdk-model.icomparisoncondition.comparison.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.icomparisoncondition.html
+++ b/v8.5.0/docs/sdk-model.icomparisoncondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idatefilter.html
+++ b/v8.5.0/docs/sdk-model.idatefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.identifier.html
+++ b/v8.5.0/docs/sdk-model.identifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.identifierref.html
+++ b/v8.5.0/docs/sdk-model.identifierref.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idimension.html
+++ b/v8.5.0/docs/sdk-model.idimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idimension.itemidentifiers.html
+++ b/v8.5.0/docs/sdk-model.idimension.itemidentifiers.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idimension.totals.html
+++ b/v8.5.0/docs/sdk-model.idimension.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idmatchattribute.html
+++ b/v8.5.0/docs/sdk-model.idmatchattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idmatchbucket.html
+++ b/v8.5.0/docs/sdk-model.idmatchbucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idmatchmeasure.html
+++ b/v8.5.0/docs/sdk-model.idmatchmeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.idref.html
+++ b/v8.5.0/docs/sdk-model.idref.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
+++ b/v8.5.0/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutionconfig.html
+++ b/v8.5.0/docs/sdk-model.iexecutionconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.attributes.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.attributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.buckets.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.buckets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.dimensions.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.dimensions.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.executionconfig.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.executionconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.filters.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.measures.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.postprocessing.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.postprocessing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.sortby.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iexecutiondefinition.workspace.html
+++ b/v8.5.0/docs/sdk-model.iexecutiondefinition.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ifilter.html
+++ b/v8.5.0/docs/sdk-model.ifilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iinsight.html
+++ b/v8.5.0/docs/sdk-model.iinsight.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iinsightdefinition.html
+++ b/v8.5.0/docs/sdk-model.iinsightdefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ilocatoritem.html
+++ b/v8.5.0/docs/sdk-model.ilocatoritem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasure.html
+++ b/v8.5.0/docs/sdk-model.imeasure.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasure.measure.html
+++ b/v8.5.0/docs/sdk-model.imeasure.measure.html
@@ -24,7 +24,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.imeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuredefinition.measuredefinition.html
+++ b/v8.5.0/docs/sdk-model.imeasuredefinition.measuredefinition.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuredefinitiontype.html
+++ b/v8.5.0/docs/sdk-model.imeasuredefinitiontype.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasurefilter.html
+++ b/v8.5.0/docs/sdk-model.imeasurefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasurelocatoritem.html
+++ b/v8.5.0/docs/sdk-model.imeasurelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
+++ b/v8.5.0/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuresortitem.html
+++ b/v8.5.0/docs/sdk-model.imeasuresortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuresortitem.measuresortitem.html
+++ b/v8.5.0/docs/sdk-model.imeasuresortitem.measuresortitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuretitle.html
+++ b/v8.5.0/docs/sdk-model.imeasuretitle.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasuretitle.measure.html
+++ b/v8.5.0/docs/sdk-model.imeasuretitle.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasurevaluefilter.html
+++ b/v8.5.0/docs/sdk-model.imeasurevaluefilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
+++ b/v8.5.0/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.inegativeattributefilter.html
+++ b/v8.5.0/docs/sdk-model.inegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
+++ b/v8.5.0/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightattributes.html
+++ b/v8.5.0/docs/sdk-model.insightattributes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightbucket.html
+++ b/v8.5.0/docs/sdk-model.insightbucket.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightbuckets.html
+++ b/v8.5.0/docs/sdk-model.insightbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightcreated.html
+++ b/v8.5.0/docs/sdk-model.insightcreated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightfilters.html
+++ b/v8.5.0/docs/sdk-model.insightfilters.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insighthasattributes.html
+++ b/v8.5.0/docs/sdk-model.insighthasattributes.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insighthasdatadefined.html
+++ b/v8.5.0/docs/sdk-model.insighthasdatadefined.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insighthasmeasures.html
+++ b/v8.5.0/docs/sdk-model.insighthasmeasures.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightid.html
+++ b/v8.5.0/docs/sdk-model.insightid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightislocked.html
+++ b/v8.5.0/docs/sdk-model.insightislocked.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightitems.html
+++ b/v8.5.0/docs/sdk-model.insightitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightmeasures.html
+++ b/v8.5.0/docs/sdk-model.insightmeasures.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightmodifyitems.html
+++ b/v8.5.0/docs/sdk-model.insightmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightproperties.html
+++ b/v8.5.0/docs/sdk-model.insightproperties.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightreduceitems.html
+++ b/v8.5.0/docs/sdk-model.insightreduceitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightref.html
+++ b/v8.5.0/docs/sdk-model.insightref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightsanitize.html
+++ b/v8.5.0/docs/sdk-model.insightsanitize.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightsetbuckets.html
+++ b/v8.5.0/docs/sdk-model.insightsetbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightsetfilters.html
+++ b/v8.5.0/docs/sdk-model.insightsetfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightsetproperties.html
+++ b/v8.5.0/docs/sdk-model.insightsetproperties.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightsetsorts.html
+++ b/v8.5.0/docs/sdk-model.insightsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightsorts.html
+++ b/v8.5.0/docs/sdk-model.insightsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insighttitle.html
+++ b/v8.5.0/docs/sdk-model.insighttitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insighttotals.html
+++ b/v8.5.0/docs/sdk-model.insighttotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insightupdated.html
+++ b/v8.5.0/docs/sdk-model.insightupdated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.insighturi.html
+++ b/v8.5.0/docs/sdk-model.insighturi.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.inullablefilter.html
+++ b/v8.5.0/docs/sdk-model.inullablefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipopmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.ipopmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipositiveattributefilter.html
+++ b/v8.5.0/docs/sdk-model.ipositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
+++ b/v8.5.0/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipostprocessing.dateformat.html
+++ b/v8.5.0/docs/sdk-model.ipostprocessing.dateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipostprocessing.html
+++ b/v8.5.0/docs/sdk-model.ipostprocessing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperioddatedataset.dataset.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperioddatedataset.dataset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperioddatedataset.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperioddatedataset.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperioddatedatasetsimple.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperioddatedatasetsimple.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperiodmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperiodmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
+++ b/v8.5.0/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irangecondition.html
+++ b/v8.5.0/docs/sdk-model.irangecondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irangecondition.range.html
+++ b/v8.5.0/docs/sdk-model.irangecondition.range.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irankingfilter.html
+++ b/v8.5.0/docs/sdk-model.irankingfilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irankingfilter.rankingfilter.html
+++ b/v8.5.0/docs/sdk-model.irankingfilter.rankingfilter.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irelativedatefilter.html
+++ b/v8.5.0/docs/sdk-model.irelativedatefilter.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irelativedatefiltervalues.from.html
+++ b/v8.5.0/docs/sdk-model.irelativedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irelativedatefiltervalues.granularity.html
+++ b/v8.5.0/docs/sdk-model.irelativedatefiltervalues.granularity.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irelativedatefiltervalues.html
+++ b/v8.5.0/docs/sdk-model.irelativedatefiltervalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irelativedatefiltervalues.to.html
+++ b/v8.5.0/docs/sdk-model.irelativedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolor.html
+++ b/v8.5.0/docs/sdk-model.irgbcolor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolor.type.html
+++ b/v8.5.0/docs/sdk-model.irgbcolor.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolor.value.html
+++ b/v8.5.0/docs/sdk-model.irgbcolor.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolorvalue.b.html
+++ b/v8.5.0/docs/sdk-model.irgbcolorvalue.b.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolorvalue.g.html
+++ b/v8.5.0/docs/sdk-model.irgbcolorvalue.g.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolorvalue.html
+++ b/v8.5.0/docs/sdk-model.irgbcolorvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.irgbcolorvalue.r.html
+++ b/v8.5.0/docs/sdk-model.irgbcolorvalue.r.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isabsolutedatefilter.html
+++ b/v8.5.0/docs/sdk-model.isabsolutedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isadhocmeasure.html
+++ b/v8.5.0/docs/sdk-model.isadhocmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isalltimedatefilter.html
+++ b/v8.5.0/docs/sdk-model.isalltimedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isarithmeticmeasure.html
+++ b/v8.5.0/docs/sdk-model.isarithmeticmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isarithmeticmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.isarithmeticmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattribute.html
+++ b/v8.5.0/docs/sdk-model.isattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattributeareasort.html
+++ b/v8.5.0/docs/sdk-model.isattributeareasort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattributeelementsbyref.html
+++ b/v8.5.0/docs/sdk-model.isattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattributeelementsbyvalue.html
+++ b/v8.5.0/docs/sdk-model.isattributeelementsbyvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattributefilter.html
+++ b/v8.5.0/docs/sdk-model.isattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattributelocator.html
+++ b/v8.5.0/docs/sdk-model.isattributelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isattributesort.html
+++ b/v8.5.0/docs/sdk-model.isattributesort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isbucket.html
+++ b/v8.5.0/docs/sdk-model.isbucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iscolorfrompalette.html
+++ b/v8.5.0/docs/sdk-model.iscolorfrompalette.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iscomparisoncondition.html
+++ b/v8.5.0/docs/sdk-model.iscomparisoncondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.iscomparisonconditionoperator.html
+++ b/v8.5.0/docs/sdk-model.iscomparisonconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isdatefilter.html
+++ b/v8.5.0/docs/sdk-model.isdatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isdimension.html
+++ b/v8.5.0/docs/sdk-model.isdimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isfilter.html
+++ b/v8.5.0/docs/sdk-model.isfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isidentifierref.html
+++ b/v8.5.0/docs/sdk-model.isidentifierref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isinsight.html
+++ b/v8.5.0/docs/sdk-model.isinsight.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.islocalidref.html
+++ b/v8.5.0/docs/sdk-model.islocalidref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ismeasure.html
+++ b/v8.5.0/docs/sdk-model.ismeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ismeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.ismeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ismeasureformatinpercent.html
+++ b/v8.5.0/docs/sdk-model.ismeasureformatinpercent.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ismeasurelocator.html
+++ b/v8.5.0/docs/sdk-model.ismeasurelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ismeasuresort.html
+++ b/v8.5.0/docs/sdk-model.ismeasuresort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ismeasurevaluefilter.html
+++ b/v8.5.0/docs/sdk-model.ismeasurevaluefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isnegativeattributefilter.html
+++ b/v8.5.0/docs/sdk-model.isnegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isobjref.html
+++ b/v8.5.0/docs/sdk-model.isobjref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isortitem.html
+++ b/v8.5.0/docs/sdk-model.isortitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ispopmeasure.html
+++ b/v8.5.0/docs/sdk-model.ispopmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ispopmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.ispopmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ispositiveattributefilter.html
+++ b/v8.5.0/docs/sdk-model.ispositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ispreviousperiodmeasure.html
+++ b/v8.5.0/docs/sdk-model.ispreviousperiodmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ispreviousperiodmeasuredefinition.html
+++ b/v8.5.0/docs/sdk-model.ispreviousperiodmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.israngecondition.html
+++ b/v8.5.0/docs/sdk-model.israngecondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.israngeconditionoperator.html
+++ b/v8.5.0/docs/sdk-model.israngeconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isrankingfilter.html
+++ b/v8.5.0/docs/sdk-model.isrankingfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isrelativedatefilter.html
+++ b/v8.5.0/docs/sdk-model.isrelativedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isrgbcolor.html
+++ b/v8.5.0/docs/sdk-model.isrgbcolor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.issimplemeasure.html
+++ b/v8.5.0/docs/sdk-model.issimplemeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.istotal.html
+++ b/v8.5.0/docs/sdk-model.istotal.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.isuriref.html
+++ b/v8.5.0/docs/sdk-model.isuriref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.itemindimension.html
+++ b/v8.5.0/docs/sdk-model.itemindimension.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.itotal.alias.html
+++ b/v8.5.0/docs/sdk-model.itotal.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.itotal.attributeidentifier.html
+++ b/v8.5.0/docs/sdk-model.itotal.attributeidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.itotal.html
+++ b/v8.5.0/docs/sdk-model.itotal.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.itotal.measureidentifier.html
+++ b/v8.5.0/docs/sdk-model.itotal.measureidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.itotal.type.html
+++ b/v8.5.0/docs/sdk-model.itotal.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ivisualizationclass.html
+++ b/v8.5.0/docs/sdk-model.ivisualizationclass.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.ivisualizationclass.visualizationclass.html
+++ b/v8.5.0/docs/sdk-model.ivisualizationclass.visualizationclass.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.localidref.html
+++ b/v8.5.0/docs/sdk-model.localidref.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureaggregation.html
+++ b/v8.5.0/docs/sdk-model.measureaggregation.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurealias.html
+++ b/v8.5.0/docs/sdk-model.measurealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurearithmeticoperands.html
+++ b/v8.5.0/docs/sdk-model.measurearithmeticoperands.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurearithmeticoperands_1.html
+++ b/v8.5.0/docs/sdk-model.measurearithmeticoperands_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurearithmeticoperator.html
+++ b/v8.5.0/docs/sdk-model.measurearithmeticoperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurearithmeticoperator_1.html
+++ b/v8.5.0/docs/sdk-model.measurearithmeticoperator_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.aggregation.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.aggregation.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.builddefinition.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.defaultaggregation.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.defaultaggregation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.filters.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.generatelocalid.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.measureitem.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.measureitem.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.nofilters.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.nofilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.noratio.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.noratio.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilder.ratio.html
+++ b/v8.5.0/docs/sdk-model.measurebuilder.ratio.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.alias.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.build.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.build.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.builddefinition.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.builddefinition.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.customlocalid.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.customlocalid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.defaultformat.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.defaultformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.defaultlocalid.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.format.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.format.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.generatelocalid.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.generatelocalid.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.initializefromexisting.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.initializefromexisting.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.localid.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.noalias.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.notitle.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.notitle.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurebuilderbase.title.html
+++ b/v8.5.0/docs/sdk-model.measurebuilderbase.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measuredoescomputeratio.html
+++ b/v8.5.0/docs/sdk-model.measuredoescomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureenvelope.html
+++ b/v8.5.0/docs/sdk-model.measureenvelope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurefilters.html
+++ b/v8.5.0/docs/sdk-model.measurefilters.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureformat.html
+++ b/v8.5.0/docs/sdk-model.measureformat.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measuregroupidentifier.html
+++ b/v8.5.0/docs/sdk-model.measuregroupidentifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureidentifier.html
+++ b/v8.5.0/docs/sdk-model.measureidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureinbucket.html
+++ b/v8.5.0/docs/sdk-model.measureinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureitem.html
+++ b/v8.5.0/docs/sdk-model.measureitem.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureitem_1.html
+++ b/v8.5.0/docs/sdk-model.measureitem_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurelocalid.html
+++ b/v8.5.0/docs/sdk-model.measurelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurelocatoridentifier.html
+++ b/v8.5.0/docs/sdk-model.measurelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measuremasteridentifier.html
+++ b/v8.5.0/docs/sdk-model.measuremasteridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measuremasteridentifier_1.html
+++ b/v8.5.0/docs/sdk-model.measuremasteridentifier_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measuremodifications.html
+++ b/v8.5.0/docs/sdk-model.measuremodifications.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureorlocalid.html
+++ b/v8.5.0/docs/sdk-model.measureorlocalid.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurepopattribute.html
+++ b/v8.5.0/docs/sdk-model.measurepopattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurepopattribute_1.html
+++ b/v8.5.0/docs/sdk-model.measurepopattribute_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurepredicate.html
+++ b/v8.5.0/docs/sdk-model.measurepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurepreviousperioddatedatasets.html
+++ b/v8.5.0/docs/sdk-model.measurepreviousperioddatedatasets.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurepreviousperioddatedatasets_1.html
+++ b/v8.5.0/docs/sdk-model.measurepreviousperioddatedatasets_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measuretitle.html
+++ b/v8.5.0/docs/sdk-model.measuretitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measureuri.html
+++ b/v8.5.0/docs/sdk-model.measureuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurevaluefiltercondition.html
+++ b/v8.5.0/docs/sdk-model.measurevaluefiltercondition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurevaluefiltermeasure.html
+++ b/v8.5.0/docs/sdk-model.measurevaluefiltermeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.measurevaluefilteroperator.html
+++ b/v8.5.0/docs/sdk-model.measurevaluefilteroperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.modifyattribute.html
+++ b/v8.5.0/docs/sdk-model.modifyattribute.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.modifymeasure.html
+++ b/v8.5.0/docs/sdk-model.modifymeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.modifypopmeasure.html
+++ b/v8.5.0/docs/sdk-model.modifypopmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.modifypreviousperiodmeasure.html
+++ b/v8.5.0/docs/sdk-model.modifypreviousperiodmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.modifysimplemeasure.html
+++ b/v8.5.0/docs/sdk-model.modifysimplemeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newabsolutedatefilter.html
+++ b/v8.5.0/docs/sdk-model.newabsolutedatefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newalltimefilter.html
+++ b/v8.5.0/docs/sdk-model.newalltimefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newarithmeticmeasure.html
+++ b/v8.5.0/docs/sdk-model.newarithmeticmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newattribute.html
+++ b/v8.5.0/docs/sdk-model.newattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newattributeareasort.html
+++ b/v8.5.0/docs/sdk-model.newattributeareasort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newattributelocator.html
+++ b/v8.5.0/docs/sdk-model.newattributelocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newattributesort.html
+++ b/v8.5.0/docs/sdk-model.newattributesort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newbucket.html
+++ b/v8.5.0/docs/sdk-model.newbucket.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newdefforbuckets.html
+++ b/v8.5.0/docs/sdk-model.newdefforbuckets.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newdefforinsight.html
+++ b/v8.5.0/docs/sdk-model.newdefforinsight.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newdefforitems.html
+++ b/v8.5.0/docs/sdk-model.newdefforitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newdimension.html
+++ b/v8.5.0/docs/sdk-model.newdimension.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newmeasure.html
+++ b/v8.5.0/docs/sdk-model.newmeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newmeasuresort.html
+++ b/v8.5.0/docs/sdk-model.newmeasuresort.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newmeasurevaluefilter.html
+++ b/v8.5.0/docs/sdk-model.newmeasurevaluefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newmeasurevaluefilter_1.html
+++ b/v8.5.0/docs/sdk-model.newmeasurevaluefilter_1.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newnegativeattributefilter.html
+++ b/v8.5.0/docs/sdk-model.newnegativeattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newpopmeasure.html
+++ b/v8.5.0/docs/sdk-model.newpopmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newpositiveattributefilter.html
+++ b/v8.5.0/docs/sdk-model.newpositiveattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newpreviousperiodmeasure.html
+++ b/v8.5.0/docs/sdk-model.newpreviousperiodmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newrankingfilter.html
+++ b/v8.5.0/docs/sdk-model.newrankingfilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newrankingfilter_1.html
+++ b/v8.5.0/docs/sdk-model.newrankingfilter_1.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newrelativedatefilter.html
+++ b/v8.5.0/docs/sdk-model.newrelativedatefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newtotal.html
+++ b/v8.5.0/docs/sdk-model.newtotal.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.newtwodimensional.html
+++ b/v8.5.0/docs/sdk-model.newtwodimensional.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.objecttype.html
+++ b/v8.5.0/docs/sdk-model.objecttype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.objref.html
+++ b/v8.5.0/docs/sdk-model.objref.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.objrefinscope.html
+++ b/v8.5.0/docs/sdk-model.objrefinscope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.popmeasurebuilder.builddefinition.html
+++ b/v8.5.0/docs/sdk-model.popmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.popmeasurebuilder.generatelocalid.html
+++ b/v8.5.0/docs/sdk-model.popmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.popmeasurebuilder.html
+++ b/v8.5.0/docs/sdk-model.popmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.popmeasurebuilder.mastermeasure.html
+++ b/v8.5.0/docs/sdk-model.popmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.popmeasurebuilder.popattribute.html
+++ b/v8.5.0/docs/sdk-model.popmeasurebuilder.popattribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.popmeasurebuilderinput.html
+++ b/v8.5.0/docs/sdk-model.popmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
+++ b/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
+++ b/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
+++ b/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.html
+++ b/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
+++ b/v8.5.0/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.previousperiodmeasurebuilderinput.html
+++ b/v8.5.0/docs/sdk-model.previousperiodmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.rangeconditionoperator.html
+++ b/v8.5.0/docs/sdk-model.rangeconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.rankingfilteroperator.html
+++ b/v8.5.0/docs/sdk-model.rankingfilteroperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.relativedatefiltervalues.html
+++ b/v8.5.0/docs/sdk-model.relativedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.rgbtype.html
+++ b/v8.5.0/docs/sdk-model.rgbtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.serializeobjref.html
+++ b/v8.5.0/docs/sdk-model.serializeobjref.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.sortdirection.html
+++ b/v8.5.0/docs/sdk-model.sortdirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.sortentityids.html
+++ b/v8.5.0/docs/sdk-model.sortentityids.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.sortmeasurelocators.html
+++ b/v8.5.0/docs/sdk-model.sortmeasurelocators.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.totalisnative.html
+++ b/v8.5.0/docs/sdk-model.totalisnative.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.totaltype.html
+++ b/v8.5.0/docs/sdk-model.totaltype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.uri.html
+++ b/v8.5.0/docs/sdk-model.uri.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.uriref.html
+++ b/v8.5.0/docs/sdk-model.uriref.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.visclassid.html
+++ b/v8.5.0/docs/sdk-model.visclassid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.visclassuri.html
+++ b/v8.5.0/docs/sdk-model.visclassuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.visclassurl.html
+++ b/v8.5.0/docs/sdk-model.visclassurl.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-model.visualizationproperties.html
+++ b/v8.5.0/docs/sdk-model.visualizationproperties.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.areachart.html
+++ b/v8.5.0/docs/sdk-ui-charts.areachart.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.axisnameposition.html
+++ b/v8.5.0/docs/sdk-ui-charts.axisnameposition.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.barchart.html
+++ b/v8.5.0/docs/sdk-ui-charts.barchart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.bubblechart.html
+++ b/v8.5.0/docs/sdk-ui-charts.bubblechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.bulletchart.html
+++ b/v8.5.0/docs/sdk-ui-charts.bulletchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.chartaligntypes.html
+++ b/v8.5.0/docs/sdk-ui-charts.chartaligntypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.columnchart.html
+++ b/v8.5.0/docs/sdk-ui-charts.columnchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.combochart.html
+++ b/v8.5.0/docs/sdk-ui-charts.combochart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.donutchart.html
+++ b/v8.5.0/docs/sdk-ui-charts.donutchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.funnelchart.html
+++ b/v8.5.0/docs/sdk-ui-charts.funnelchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.headline.html
+++ b/v8.5.0/docs/sdk-ui-charts.headline.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.heatmap.html
+++ b/v8.5.0/docs/sdk-ui-charts.heatmap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.html
+++ b/v8.5.0/docs/sdk-ui-charts.html
@@ -164,7 +164,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iareachartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iareachartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.max.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.max.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.min.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.min.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.name.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.name.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.rotation.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.rotation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisconfig.visible.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisnameconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisnameconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisnameconfig.position.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisnameconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iaxisnameconfig.visible.html
+++ b/v8.5.0/docs/sdk-ui-charts.iaxisnameconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibarchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibarchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibubblechartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibubblechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibucketchartprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibucketchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibucketchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibucketchartprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibucketchartprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibucketchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ibulletchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ibulletchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartcallbacks.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartcallbacks.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.colormapping.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.colormapping.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.colorpalette.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.colorpalette.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.colors.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.colors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.datalabels.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.datalabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.datapoints.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.datapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.dualaxis.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.dualaxis.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.grid.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.grid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.html
@@ -111,7 +111,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.legend.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.legend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.legendlayout.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.legendlayout.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.separators.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.xaxis.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.xformat.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.xformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.xlabel.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.xlabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.yaxis.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.yformat.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.yformat.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.ylabel.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.ylabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartconfig.zoominsight.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartconfig.zoominsight.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartlimits.categories.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartlimits.categories.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartlimits.datapoints.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartlimits.datapoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartlimits.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartlimits.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ichartlimits.series.html
+++ b/v8.5.0/docs/sdk-ui-charts.ichartlimits.series.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icolumnchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.icolumnchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icombochartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.icombochartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icommonchartprops.config.html
+++ b/v8.5.0/docs/sdk-ui-charts.icommonchartprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icommonchartprops.height.html
+++ b/v8.5.0/docs/sdk-ui-charts.icommonchartprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icommonchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.icommonchartprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.icommonchartprops.width.html
+++ b/v8.5.0/docs/sdk-ui-charts.icommonchartprops.width.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idatalabelsconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.idatalabelsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idatalabelsconfig.visible.html
+++ b/v8.5.0/docs/sdk-ui-charts.idatalabelsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idatalabelsvisible.html
+++ b/v8.5.0/docs/sdk-ui-charts.idatalabelsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idatapointsconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.idatapointsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idatapointsconfig.visible.html
+++ b/v8.5.0/docs/sdk-ui-charts.idatapointsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idatapointsvisible.html
+++ b/v8.5.0/docs/sdk-ui-charts.idatapointsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.idonutchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.idonutchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ifunnelchartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ifunnelchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.igridconfig.enabled.html
+++ b/v8.5.0/docs/sdk-ui-charts.igridconfig.enabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.igridconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.igridconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheadlineprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheadlineprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iheatmapprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iheatmapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegendconfig.enabled.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegendconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegendconfig.position.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegendconfig.responsive.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegenddata.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegenddata.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegenddata.legenditems.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegenddata.legenditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegenditem.color.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegenditem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegenditem.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegenditem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegenditem.name.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegenditem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilegenditem.onclick.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilegenditem.onclick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ilinechartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ilinechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ipiechartprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ipiechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.iscatterplotprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.iscatterplotprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itooltipconfig.enabled.html
+++ b/v8.5.0/docs/sdk-ui-charts.itooltipconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itooltipconfig.html
+++ b/v8.5.0/docs/sdk-ui-charts.itooltipconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.itreemapprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.itreemapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
+++ b/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.measure.html
+++ b/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.ixirrprops.html
+++ b/v8.5.0/docs/sdk-ui-charts.ixirrprops.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.linechart.html
+++ b/v8.5.0/docs/sdk-ui-charts.linechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.onlegendready.html
+++ b/v8.5.0/docs/sdk-ui-charts.onlegendready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.piechart.html
+++ b/v8.5.0/docs/sdk-ui-charts.piechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.positiontype.html
+++ b/v8.5.0/docs/sdk-ui-charts.positiontype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.scatterplot.html
+++ b/v8.5.0/docs/sdk-ui-charts.scatterplot.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.treemap.html
+++ b/v8.5.0/docs/sdk-ui-charts.treemap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.viewbyattributeslimit.html
+++ b/v8.5.0/docs/sdk-ui-charts.viewbyattributeslimit.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-charts.xirr.html
+++ b/v8.5.0/docs/sdk-ui-charts.xirr.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.absolutedatefilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.absolutedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.attributeelements.html
+++ b/v8.5.0/docs/sdk-ui-filters.attributeelements.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.attributefilter.html
+++ b/v8.5.0/docs/sdk-ui-filters.attributefilter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.attributefilterbutton.html
+++ b/v8.5.0/docs/sdk-ui-filters.attributefilterbutton.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilter._constructor_.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilter._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilter.componentdidmount.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilter.componentdidmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilter.defaultprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilter.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilter.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilter.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilter.render.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilter.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilterhelpers.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilterhelpers.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
+++ b/v8.5.0/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.defaultdatefilteroptions.html
+++ b/v8.5.0/docs/sdk-ui-filters.defaultdatefilteroptions.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
+++ b/v8.5.0/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.html
+++ b/v8.5.0/docs/sdk-ui-filters.html
@@ -157,7 +157,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.ref.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.title.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.type.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributedropdownitem.type.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.error.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.error.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.children.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.children.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.limit.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.offset.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.options.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterbuttonprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.filter.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.identifier.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.locale.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.onapply.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.onerror.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.title.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-filters.iattributefilterprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.icustomgranularityselection.enable.html
+++ b/v8.5.0/docs/sdk-ui-filters.icustomgranularityselection.enable.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.icustomgranularityselection.html
+++ b/v8.5.0/docs/sdk-ui-filters.icustomgranularityselection.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
+++ b/v8.5.0/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.locale.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterownprops.locale.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterprops.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstate.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstate.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
+++ b/v8.5.0/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iextendeddatefiltererrors.html
+++ b/v8.5.0/docs/sdk-ui-filters.iextendeddatefiltererrors.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
+++ b/v8.5.0/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.title.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasuredropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterstate.html
+++ b/v8.5.0/docs/sdk-ui-filters.imeasurevaluefilterstate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.filter.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.locale.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.onapply.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
+++ b/v8.5.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.isabsolutedatefilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.isabsolutedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.isrelativedatefilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.isrelativedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.isuirelativedatefilterform.html
+++ b/v8.5.0/docs/sdk-ui-filters.isuirelativedatefilterform.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
+++ b/v8.5.0/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.iwarningmessage.html
+++ b/v8.5.0/docs/sdk-ui-filters.iwarningmessage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.render.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.state.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilter.state.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilterdropdown.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilterdropdown.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
+++ b/v8.5.0/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.rankingfilter.html
+++ b/v8.5.0/docs/sdk-ui-filters.rankingfilter.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.rankingfilterdropdown.html
+++ b/v8.5.0/docs/sdk-ui-filters.rankingfilterdropdown.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.relativedatefilteroption.html
+++ b/v8.5.0/docs/sdk-ui-filters.relativedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-filters.warningmessage.html
+++ b/v8.5.0/docs/sdk-ui-filters.warningmessage.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.centerpositionchangedcallback.html
+++ b/v8.5.0/docs/sdk-ui-geo.centerpositionchangedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.geopushpinchart.html
+++ b/v8.5.0/docs/sdk-ui-geo.geopushpinchart.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.html
+++ b/v8.5.0/docs/sdk-ui-geo.html
@@ -115,7 +115,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoattributeitem.data.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoattributeitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoattributeitem.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoattributeitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.center.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.center.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.colormapping.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.colormapping.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.colorpalette.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.colorpalette.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.colors.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.colors.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.isexportmode.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.isexportmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.legend.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.legend.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.limit.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.points.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.separators.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.separators.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.showlabels.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.showlabels.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.viewport.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.viewport.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfig.zoom.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfig.zoom.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfigviewport.area.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfigviewport.area.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfigviewport.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfigviewport.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeoconfigviewportarea.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeoconfigviewportarea.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodata.color.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodata.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodata.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodata.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodata.location.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodata.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodata.segment.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodata.segment.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodata.size.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodata.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodata.tooltiptext.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodata.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodataitem.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodataitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodataitem.index.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodataitem.index.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeodataitem.name.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeodataitem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.enabled.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.position.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.responsive.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolnglat.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolnglat.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolnglat.lat.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolnglat.lat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolnglat.lng.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolnglat.lng.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolocationitem.data.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolocationitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeolocationitem.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeolocationitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeomeasureitem.data.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeomeasureitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeomeasureitem.format.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeomeasureitem.format.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeomeasureitem.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeomeasureitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.minsize.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopointsconfig.minsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.color.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.config.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.config.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.location.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.size.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeosegmentitem.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeosegmentitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.igeosegmentitem.uris.html
+++ b/v8.5.0/docs/sdk-ui-geo.igeosegmentitem.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.pushpinsizeoption.html
+++ b/v8.5.0/docs/sdk-ui-geo.pushpinsizeoption.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-geo.zoomchangedcallback.html
+++ b/v8.5.0/docs/sdk-ui-geo.zoomchangedcallback.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.columnlocator.html
+++ b/v8.5.0/docs/sdk-ui-pivot.columnlocator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.columnresizedcallback.html
+++ b/v8.5.0/docs/sdk-ui-pivot.columnresizedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.columnwidth.html
+++ b/v8.5.0/docs/sdk-ui-pivot.columnwidth.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.columnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.columnwidthitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.defaultcolumnwidth.html
+++ b/v8.5.0/docs/sdk-ui-pivot.defaultcolumnwidth.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.html
+++ b/v8.5.0/docs/sdk-ui-pivot.html
@@ -139,7 +139,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iattributecolumnlocator.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iattributecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iautocolumnwidth.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iautocolumnwidth.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iautocolumnwidth.value.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iautocolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
+++ b/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
+++ b/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
+++ b/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.html
+++ b/v8.5.0/docs/sdk-ui-pivot.icolumnsizing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnlocator.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imenu.aggregations.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imenu.aggregations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imenu.aggregationtypes.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imenu.aggregationtypes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.imenu.html
+++ b/v8.5.0/docs/sdk-ui-pivot.imenu.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.menu.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.menu.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.separators.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableprops.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ipivottableprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ipivottableprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
+++ b/v8.5.0/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.isattributecolumnlocator.html
+++ b/v8.5.0/docs/sdk-ui-pivot.isattributecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.5.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.newattributecolumnlocator.html
+++ b/v8.5.0/docs/sdk-ui-pivot.newattributecolumnlocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
+++ b/v8.5.0/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
+++ b/v8.5.0/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.newwidthforattributecolumn.html
+++ b/v8.5.0/docs/sdk-ui-pivot.newwidthforattributecolumn.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
+++ b/v8.5.0/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.pivottable.html
+++ b/v8.5.0/docs/sdk-ui-pivot.pivottable.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
+++ b/v8.5.0/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.html
@@ -114,7 +114,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.themecontextprovider.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.themecontextprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.thememodifier.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.thememodifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.themeprovider.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.themeprovider.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.usetheme.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.usetheme.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.usethemeisloading.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.usethemeisloading.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-theme-provider.withtheme.html
+++ b/v8.5.0/docs/sdk-ui-theme-provider.withtheme.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
+++ b/v8.5.0/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-vis-commons.html
+++ b/v8.5.0/docs/sdk-ui-vis-commons.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-vis-commons.icolormapping.color.html
+++ b/v8.5.0/docs/sdk-ui-vis-commons.icolormapping.color.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-vis-commons.icolormapping.html
+++ b/v8.5.0/docs/sdk-ui-vis-commons.icolormapping.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui-vis-commons.icolormapping.predicate.html
+++ b/v8.5.0/docs/sdk-ui-vis-commons.icolormapping.predicate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.anyarrayof.html
+++ b/v8.5.0/docs/sdk-ui.anyarrayof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.anymeasure.html
+++ b/v8.5.0/docs/sdk-ui.anymeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.anyplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.anyplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.anyplaceholderof.html
+++ b/v8.5.0/docs/sdk-ui.anyplaceholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.arrayof.html
+++ b/v8.5.0/docs/sdk-ui.arrayof.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributefilterorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.attributefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributefiltersorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.attributefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributeitemnamematch.html
+++ b/v8.5.0/docs/sdk-ui.attributeitemnamematch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributemeasureorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.attributemeasureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributeorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.attributeorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributesmeasuresorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.attributesmeasuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.attributesorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.attributesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.backendprovider.html
+++ b/v8.5.0/docs/sdk-ui.backendprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.badrequestsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.badrequestsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.badrequestsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.badrequestsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cancelledsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.cancelledsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cancelledsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.cancelledsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.attribute.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.attribute.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.attributedisplayform.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.attributedisplayform.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.attributes.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.attributes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.attributetags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.attributetags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedataset.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedataset.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetattribute.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetattribute.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedatasets.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.datedatasettags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.datedatasettags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.html
@@ -122,7 +122,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.measure.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.measure.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.measures.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.measuretags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.measuretags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.visualization.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.visualization.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.visualizations.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.cataloghelper.visualizationtags.html
+++ b/v8.5.0/docs/sdk-ui.cataloghelper.visualizationtags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.chartelementtype.html
+++ b/v8.5.0/docs/sdk-ui.chartelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.charttype.html
+++ b/v8.5.0/docs/sdk-ui.charttype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.composedfromidentifier.html
+++ b/v8.5.0/docs/sdk-ui.composedfromidentifier.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.composedfromuri.html
+++ b/v8.5.0/docs/sdk-ui.composedfromuri.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.composedplaceholderresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui.composedplaceholderresolutioncontext.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.converterror.html
+++ b/v8.5.0/docs/sdk-ui.converterror.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.createnumberjsformatter.html
+++ b/v8.5.0/docs/sdk-ui.createnumberjsformatter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataaccessconfig.html
+++ b/v8.5.0/docs/sdk-ui.dataaccessconfig.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datapoint.html
+++ b/v8.5.0/docs/sdk-ui.datapoint.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datapointcoordinates.html
+++ b/v8.5.0/docs/sdk-ui.datapointcoordinates.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataseriesdescriptor.html
+++ b/v8.5.0/docs/sdk-ui.dataseriesdescriptor.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataseriesdescriptormethods.html
+++ b/v8.5.0/docs/sdk-ui.dataseriesdescriptormethods.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataseriesheaders.html
+++ b/v8.5.0/docs/sdk-ui.dataseriesheaders.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataseriesid.html
+++ b/v8.5.0/docs/sdk-ui.dataseriesid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataslicedescriptor.html
+++ b/v8.5.0/docs/sdk-ui.dataslicedescriptor.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataslicedescriptormethods.html
+++ b/v8.5.0/docs/sdk-ui.dataslicedescriptormethods.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datasliceheaders.html
+++ b/v8.5.0/docs/sdk-ui.datasliceheaders.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datasliceid.html
+++ b/v8.5.0/docs/sdk-ui.datasliceid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datatoolargetocomputesdkerror.html
+++ b/v8.5.0/docs/sdk-ui.datatoolargetocomputesdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.datatoolargetodisplaysdkerror.html
+++ b/v8.5.0/docs/sdk-ui.datatoolargetodisplaysdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.data.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.data.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.dataview.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.definition.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.definition.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.fingerprint.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.fingerprint.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.for.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.for.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.html
@@ -110,7 +110,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.result.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.result.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewfacade.warnings.html
+++ b/v8.5.0/docs/sdk-ui.dataviewfacade.warnings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.dataviewwindow.html
+++ b/v8.5.0/docs/sdk-ui.dataviewwindow.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.defaultcolorpalette.html
+++ b/v8.5.0/docs/sdk-ui.defaultcolorpalette.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.defaultdataaccessconfig.html
+++ b/v8.5.0/docs/sdk-ui.defaultdataaccessconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.defaulterrorhandler.html
+++ b/v8.5.0/docs/sdk-ui.defaulterrorhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.defaultlocale.html
+++ b/v8.5.0/docs/sdk-ui.defaultlocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.drilleventintersectionelementheader.html
+++ b/v8.5.0/docs/sdk-ui.drilleventintersectionelementheader.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.errorcodes.html
+++ b/v8.5.0/docs/sdk-ui.errorcodes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.errorcomponent.defaultprops.html
+++ b/v8.5.0/docs/sdk-ui.errorcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.errorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.errorcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.errorcomponent.render.html
+++ b/v8.5.0/docs/sdk-ui.errorcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.execute.html
+++ b/v8.5.0/docs/sdk-ui.execute.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.executeinsight.html
+++ b/v8.5.0/docs/sdk-ui.executeinsight.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.filterormultivalueplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.filterormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.filterorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.filterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.filtersorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.filtersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.flatten.html
+++ b/v8.5.0/docs/sdk-ui.flatten.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.geolocationmissingsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.geolocationmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.geotokenmissingsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.geotokenmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror.cause.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror.getcause.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror.getcause.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror.getmessage.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror.getmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror.html
@@ -106,7 +106,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.gooddatasdkerror.setype.html
+++ b/v8.5.0/docs/sdk-ui.gooddatasdkerror.setype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.headerpredicates.html
+++ b/v8.5.0/docs/sdk-ui.headerpredicates.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.headertranslator.html
+++ b/v8.5.0/docs/sdk-ui.headertranslator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.headlineelementtype.html
+++ b/v8.5.0/docs/sdk-ui.headlineelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.headlinetype.html
+++ b/v8.5.0/docs/sdk-ui.headlinetype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.html
+++ b/v8.5.0/docs/sdk-ui.html
@@ -330,7 +330,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iattritem.defaultdisplayform.html
+++ b/v8.5.0/docs/sdk-ui.iattritem.defaultdisplayform.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iattritem.displayforms.html
+++ b/v8.5.0/docs/sdk-ui.iattritem.displayforms.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iattritem.html
+++ b/v8.5.0/docs/sdk-ui.iattritem.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iattritem.identifier.html
+++ b/v8.5.0/docs/sdk-ui.iattritem.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iattritem.tags.html
+++ b/v8.5.0/docs/sdk-ui.iattritem.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iattrs.html
+++ b/v8.5.0/docs/sdk-ui.iattrs.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ibackendproviderprops.backend.html
+++ b/v8.5.0/docs/sdk-ui.ibackendproviderprops.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ibackendproviderprops.html
+++ b/v8.5.0/docs/sdk-ui.ibackendproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icatalog.attributes.html
+++ b/v8.5.0/docs/sdk-ui.icatalog.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icatalog.datedatasets.html
+++ b/v8.5.0/docs/sdk-ui.icatalog.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icatalog.html
+++ b/v8.5.0/docs/sdk-ui.icatalog.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icatalog.measures.html
+++ b/v8.5.0/docs/sdk-ui.icatalog.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icatalog.visualizations.html
+++ b/v8.5.0/docs/sdk-ui.icatalog.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icomposedplaceholder.computevalue.html
+++ b/v8.5.0/docs/sdk-ui.icomposedplaceholder.computevalue.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icomposedplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.icomposedplaceholder.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icomposedplaceholder.placeholders.html
+++ b/v8.5.0/docs/sdk-ui.icomposedplaceholder.placeholders.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icomposedplaceholder.type.html
+++ b/v8.5.0/docs/sdk-ui.icomposedplaceholder.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.icomposedplaceholder.use.html
+++ b/v8.5.0/docs/sdk-ui.icomposedplaceholder.use.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataaccessmethods.html
+++ b/v8.5.0/docs/sdk-ui.idataaccessmethods.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataaccessmethods.series.html
+++ b/v8.5.0/docs/sdk-ui.idataaccessmethods.series.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataaccessmethods.slices.html
+++ b/v8.5.0/docs/sdk-ui.idataaccessmethods.slices.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseries.datapoints.html
+++ b/v8.5.0/docs/sdk-ui.idataseries.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseries.descriptor.html
+++ b/v8.5.0/docs/sdk-ui.idataseries.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseries.html
+++ b/v8.5.0/docs/sdk-ui.idataseries.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseries.id.html
+++ b/v8.5.0/docs/sdk-ui.idataseries.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseries.rawdata.html
+++ b/v8.5.0/docs/sdk-ui.idataseries.rawdata.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.allformeasure.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.allformeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.count.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.firstformeasure.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.firstformeasure.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.frommeasures.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.frommeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.html
@@ -100,7 +100,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.scopingattributes.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.scopingattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataseriescollection.toarray.html
+++ b/v8.5.0/docs/sdk-ui.idataseriescollection.toarray.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataset.attributes.html
+++ b/v8.5.0/docs/sdk-ui.idataset.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataset.html
+++ b/v8.5.0/docs/sdk-ui.idataset.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataset.identifier.html
+++ b/v8.5.0/docs/sdk-ui.idataset.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataset.tags.html
+++ b/v8.5.0/docs/sdk-ui.idataset.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslice.datapoints.html
+++ b/v8.5.0/docs/sdk-ui.idataslice.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslice.descriptor.html
+++ b/v8.5.0/docs/sdk-ui.idataslice.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslice.html
+++ b/v8.5.0/docs/sdk-ui.idataslice.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslice.id.html
+++ b/v8.5.0/docs/sdk-ui.idataslice.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslice.rawdata.html
+++ b/v8.5.0/docs/sdk-ui.idataslice.rawdata.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslicecollection.count.html
+++ b/v8.5.0/docs/sdk-ui.idataslicecollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslicecollection.descriptors.html
+++ b/v8.5.0/docs/sdk-ui.idataslicecollection.descriptors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslicecollection.html
+++ b/v8.5.0/docs/sdk-ui.idataslicecollection.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idataslicecollection.toarray.html
+++ b/v8.5.0/docs/sdk-ui.idataslicecollection.toarray.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idatavisualizationprops.execution.html
+++ b/v8.5.0/docs/sdk-ui.idatavisualizationprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idatavisualizationprops.html
+++ b/v8.5.0/docs/sdk-ui.idatavisualizationprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.identifiermatch.html
+++ b/v8.5.0/docs/sdk-ui.identifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idisplayforms.html
+++ b/v8.5.0/docs/sdk-ui.idisplayforms.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillableitem.html
+++ b/v8.5.0/docs/sdk-ui.idrillableitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillableitemidentifier.html
+++ b/v8.5.0/docs/sdk-ui.idrillableitemidentifier.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillableitemidentifier.identifier.html
+++ b/v8.5.0/docs/sdk-ui.idrillableitemidentifier.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillableitemuri.html
+++ b/v8.5.0/docs/sdk-ui.idrillableitemuri.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillableitemuri.uri.html
+++ b/v8.5.0/docs/sdk-ui.idrillableitemuri.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillconfig.dataview.html
+++ b/v8.5.0/docs/sdk-ui.idrillconfig.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillconfig.html
+++ b/v8.5.0/docs/sdk-ui.idrillconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillconfig.ondrill.html
+++ b/v8.5.0/docs/sdk-ui.idrillconfig.ondrill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillevent.dataview.html
+++ b/v8.5.0/docs/sdk-ui.idrillevent.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillevent.drillcontext.html
+++ b/v8.5.0/docs/sdk-ui.idrillevent.drillcontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillevent.html
+++ b/v8.5.0/docs/sdk-ui.idrillevent.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcallback.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.columnindex.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.element.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.intersection.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.points.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.row.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.rowindex.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.type.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.value.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.x.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.y.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontext.z.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontext.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.element.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.points.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.type.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextgroup.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.element.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.intersection.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.type.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.value.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextheadline.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.element.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.intersection.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.type.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.value.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.x.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.y.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.z.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextpoint.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.columnindex.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.element.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.intersection.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.row.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.rowindex.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontexttable.type.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontexttable.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.element.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.intersection.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.type.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.value.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventcontextxirr.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventintersectionelement.header.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventintersectionelement.header.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrilleventintersectionelement.html
+++ b/v8.5.0/docs/sdk-ui.idrilleventintersectionelement.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillintersectionattributeitem.html
+++ b/v8.5.0/docs/sdk-ui.idrillintersectionattributeitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillpoint.html
+++ b/v8.5.0/docs/sdk-ui.idrillpoint.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillpoint.intersection.html
+++ b/v8.5.0/docs/sdk-ui.idrillpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillpoint.type.html
+++ b/v8.5.0/docs/sdk-ui.idrillpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillpoint.x.html
+++ b/v8.5.0/docs/sdk-ui.idrillpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.idrillpoint.y.html
+++ b/v8.5.0/docs/sdk-ui.idrillpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrordescriptors.html
+++ b/v8.5.0/docs/sdk-ui.ierrordescriptors.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.classname.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.clientheight.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.clientheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.code.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.code.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.description.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.height.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.icon.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.icon.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.message.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.message.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.style.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.style.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ierrorprops.width.html
+++ b/v8.5.0/docs/sdk-ui.ierrorprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteerrorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteerrorcomponent.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteerrorcomponentprops.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteerrorcomponentprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.backend.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.children.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.children.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.componentname.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.dateformat.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.dimensions.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.filters.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.insight.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.insight.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.sorts.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.window.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.window.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteinsightprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteinsightprops.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteloadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteloadingcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.backend.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.children.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.componentname.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.componentname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.errorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.errorcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.exporttitle.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.filters.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.loadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.loadonmount.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.seriesby.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.seriesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.slicesby.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.slicesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.sortby.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.totals.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.window.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecuteprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui.iexecuteprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.componentname.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.filters.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.seriesby.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.slicesby.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.sortby.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexecutionconfiguration.totals.html
+++ b/v8.5.0/docs/sdk-ui.iexecutionconfiguration.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iexportfunction.html
+++ b/v8.5.0/docs/sdk-ui.iexportfunction.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iextendedexportconfig.html
+++ b/v8.5.0/docs/sdk-ui.iextendedexportconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
+++ b/v8.5.0/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iheaderpredicate.html
+++ b/v8.5.0/docs/sdk-ui.iheaderpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iheaderpredicatecontext.dv.html
+++ b/v8.5.0/docs/sdk-ui.iheaderpredicatecontext.dv.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iheaderpredicatecontext.html
+++ b/v8.5.0/docs/sdk-ui.iheaderpredicatecontext.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ihighchartscategoriestree.html
+++ b/v8.5.0/docs/sdk-ui.ihighchartscategoriestree.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ihighchartscategoriestree.tick.html
+++ b/v8.5.0/docs/sdk-ui.ihighchartscategoriestree.tick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ihighchartsparenttick.html
+++ b/v8.5.0/docs/sdk-ui.ihighchartsparenttick.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ihighchartsparenttick.label.html
+++ b/v8.5.0/docs/sdk-ui.ihighchartsparenttick.label.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ihighchartsparenttick.leaves.html
+++ b/v8.5.0/docs/sdk-ui.ihighchartsparenttick.leaves.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ihighchartsparenttick.startat.html
+++ b/v8.5.0/docs/sdk-ui.ihighchartsparenttick.startat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iidentifierwithtags.html
+++ b/v8.5.0/docs/sdk-ui.iidentifierwithtags.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iidentifierwithtags.identifier.html
+++ b/v8.5.0/docs/sdk-ui.iidentifierwithtags.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iidentifierwithtags.tags.html
+++ b/v8.5.0/docs/sdk-ui.iidentifierwithtags.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.backend.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.errorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.filters.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.loadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.locale.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.measure.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.separators.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ikpiprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui.ikpiprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.classname.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.color.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.height.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.height.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.imageheight.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.imageheight.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.imagewidth.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.imagewidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.inline.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.inline.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.speed.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.speed.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingprops.width.html
+++ b/v8.5.0/docs/sdk-ui.iloadingprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingstate.html
+++ b/v8.5.0/docs/sdk-ui.iloadingstate.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iloadingstate.isloading.html
+++ b/v8.5.0/docs/sdk-ui.iloadingstate.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ilocale.html
+++ b/v8.5.0/docs/sdk-ui.ilocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.imappingheader.html
+++ b/v8.5.0/docs/sdk-ui.imappingheader.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholderoptions.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholderoptions.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholderoptions.id.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholderoptions.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholderoptions.validate.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholderoptions.validate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholdersproviderprops.children.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholdersproviderprops.children.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholdersproviderprops.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholdersproviderprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
+++ b/v8.5.0/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.children.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.errorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.execution.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.exporttitle.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.loadonmount.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.irawexecuteprops.window.html
+++ b/v8.5.0/docs/sdk-ui.irawexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isanyplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.isanyplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isbadrequest.html
+++ b/v8.5.0/docs/sdk-ui.isbadrequest.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iscancelledsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.iscancelledsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iscomposedplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.iscomposedplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isdatatoolargetocompute.html
+++ b/v8.5.0/docs/sdk-ui.isdatatoolargetocompute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isdatatoolargetodisplay.html
+++ b/v8.5.0/docs/sdk-ui.isdatatoolargetodisplay.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isdrillableitemidentifier.html
+++ b/v8.5.0/docs/sdk-ui.isdrillableitemidentifier.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isdrillableitemuri.html
+++ b/v8.5.0/docs/sdk-ui.isdrillableitemuri.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isdrillintersectionattributeitem.html
+++ b/v8.5.0/docs/sdk-ui.isdrillintersectionattributeitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isgeolocationmissing.html
+++ b/v8.5.0/docs/sdk-ui.isgeolocationmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isgeotokenmissing.html
+++ b/v8.5.0/docs/sdk-ui.isgeotokenmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isgooddatasdkerror.html
+++ b/v8.5.0/docs/sdk-ui.isgooddatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isheaderpredicate.html
+++ b/v8.5.0/docs/sdk-ui.isheaderpredicate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isnegativevalues.html
+++ b/v8.5.0/docs/sdk-ui.isnegativevalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isnodatasdkerror.html
+++ b/v8.5.0/docs/sdk-ui.isnodatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isnotfound.html
+++ b/v8.5.0/docs/sdk-ui.isnotfound.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.isplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isprotectedreport.html
+++ b/v8.5.0/docs/sdk-ui.isprotectedreport.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isunauthorized.html
+++ b/v8.5.0/docs/sdk-ui.isunauthorized.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.isunknownsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.isunknownsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iusecomposedplaceholderhook.html
+++ b/v8.5.0/docs/sdk-ui.iusecomposedplaceholderhook.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.backend.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.componentname.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.filters.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.seriesby.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.slicesby.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.sortby.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.totals.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutionconfig.workspace.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutionconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
+++ b/v8.5.0/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.window.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
+++ b/v8.5.0/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iusepagedresourceresult.html
+++ b/v8.5.0/docs/sdk-ui.iusepagedresourceresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iusepagedresourceresult.isloading.html
+++ b/v8.5.0/docs/sdk-ui.iusepagedresourceresult.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iusepagedresourcestate.html
+++ b/v8.5.0/docs/sdk-ui.iusepagedresourcestate.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iusepagedresourcestate.items.html
+++ b/v8.5.0/docs/sdk-ui.iusepagedresourcestate.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
+++ b/v8.5.0/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iuseplaceholderhook.html
+++ b/v8.5.0/docs/sdk-ui.iuseplaceholderhook.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.onerror.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationprops.drillableitems.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationprops.drillableitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationprops.errorcomponent.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationprops.exporttitle.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationprops.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.ivisualizationprops.locale.html
+++ b/v8.5.0/docs/sdk-ui.ivisualizationprops.locale.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iwithloadingevents.html
+++ b/v8.5.0/docs/sdk-ui.iwithloadingevents.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iwithloadingevents.onerror.html
+++ b/v8.5.0/docs/sdk-ui.iwithloadingevents.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iwithloadingevents.onexportready.html
+++ b/v8.5.0/docs/sdk-ui.iwithloadingevents.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
+++ b/v8.5.0/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
+++ b/v8.5.0/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iwithloadingevents.onloadingstart.html
+++ b/v8.5.0/docs/sdk-ui.iwithloadingevents.onloadingstart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iworkspaceproviderprops.html
+++ b/v8.5.0/docs/sdk-ui.iworkspaceproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.iworkspaceproviderprops.workspace.html
+++ b/v8.5.0/docs/sdk-ui.iworkspaceproviderprops.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.kpi.html
+++ b/v8.5.0/docs/sdk-ui.kpi.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.loadingcomponent.defaultprops.html
+++ b/v8.5.0/docs/sdk-ui.loadingcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.loadingcomponent.html
+++ b/v8.5.0/docs/sdk-ui.loadingcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.loadingcomponent.render.html
+++ b/v8.5.0/docs/sdk-ui.loadingcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.localidentifiermatch.html
+++ b/v8.5.0/docs/sdk-ui.localidentifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.measureof.html
+++ b/v8.5.0/docs/sdk-ui.measureof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.measureorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.measureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.measuresorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.measuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.negativevaluessdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.negativevaluessdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.negativevaluessdkerror.html
+++ b/v8.5.0/docs/sdk-ui.negativevaluessdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.newcomposedplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.newcomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.newerrormapping.html
+++ b/v8.5.0/docs/sdk-ui.newerrormapping.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.newplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.newplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.nodatasdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.nodatasdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.nodatasdkerror.html
+++ b/v8.5.0/docs/sdk-ui.nodatasdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.notfoundsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.notfoundsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.notfoundsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.notfoundsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.nullablefilterorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.nullablefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.nullablefiltersorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.nullablefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.onerror.html
+++ b/v8.5.0/docs/sdk-ui.onerror.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.onexportready.html
+++ b/v8.5.0/docs/sdk-ui.onexportready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.onfireddrillevent.html
+++ b/v8.5.0/docs/sdk-ui.onfireddrillevent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.onloadingchanged.html
+++ b/v8.5.0/docs/sdk-ui.onloadingchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.placeholderof.html
+++ b/v8.5.0/docs/sdk-ui.placeholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.placeholderresolvedvalue.html
+++ b/v8.5.0/docs/sdk-ui.placeholderresolvedvalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.placeholdersprovider.html
+++ b/v8.5.0/docs/sdk-ui.placeholdersprovider.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.placeholdersresolvedvalues.html
+++ b/v8.5.0/docs/sdk-ui.placeholdersresolvedvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.placeholdersvalues.html
+++ b/v8.5.0/docs/sdk-ui.placeholdersvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.placeholdervalue.html
+++ b/v8.5.0/docs/sdk-ui.placeholdervalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.protectedreportsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.protectedreportsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.protectedreportsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.protectedreportsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.rawexecute.html
+++ b/v8.5.0/docs/sdk-ui.rawexecute.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.resolveusecancelablepromiseserror.html
+++ b/v8.5.0/docs/sdk-ui.resolveusecancelablepromiseserror.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.resolveusecancelablepromisesstatus.html
+++ b/v8.5.0/docs/sdk-ui.resolveusecancelablepromisesstatus.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.sdkerrortype.html
+++ b/v8.5.0/docs/sdk-ui.sdkerrortype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.sortsorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.sortsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.tableelementtype.html
+++ b/v8.5.0/docs/sdk-ui.tableelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.tabletype.html
+++ b/v8.5.0/docs/sdk-ui.tabletype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.totalsorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.totalsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
+++ b/v8.5.0/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.unauthorizedsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.unauthorizedsdkerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.unexpectedsdkerror._constructor_.html
+++ b/v8.5.0/docs/sdk-ui.unexpectedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.unexpectedsdkerror.html
+++ b/v8.5.0/docs/sdk-ui.unexpectedsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.uniontointersection.html
+++ b/v8.5.0/docs/sdk-ui.uniontointersection.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.urimatch.html
+++ b/v8.5.0/docs/sdk-ui.urimatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usebackend.html
+++ b/v8.5.0/docs/sdk-ui.usebackend.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usebackendstrict.html
+++ b/v8.5.0/docs/sdk-ui.usebackendstrict.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromise.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromise.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromisecallbacks.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromisecallbacks.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromiseerrorstate.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromiseerrorstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromiseloadingstate.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromiseloadingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromisependingstate.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromisependingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromisestate.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromisestate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromisestatus.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromisestatus.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecancelablepromisesuccessstate.html
+++ b/v8.5.0/docs/sdk-ui.usecancelablepromisesuccessstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usecomposedplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.usecomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usedataexport.html
+++ b/v8.5.0/docs/sdk-ui.usedataexport.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usedataexportcallbacks.html
+++ b/v8.5.0/docs/sdk-ui.usedataexportcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usedataexportstate.html
+++ b/v8.5.0/docs/sdk-ui.usedataexportstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usedataview.html
+++ b/v8.5.0/docs/sdk-ui.usedataview.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usedataviewcallbacks.html
+++ b/v8.5.0/docs/sdk-ui.usedataviewcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usedataviewstate.html
+++ b/v8.5.0/docs/sdk-ui.usedataviewstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useexecution.html
+++ b/v8.5.0/docs/sdk-ui.useexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useexecutiondataview.html
+++ b/v8.5.0/docs/sdk-ui.useexecutiondataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useinsightdataview.html
+++ b/v8.5.0/docs/sdk-ui.useinsightdataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.usepagedresource.html
+++ b/v8.5.0/docs/sdk-ui.usepagedresource.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.useplaceholder.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.useplaceholders.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useresolvevalueswithplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.useresolvevalueswithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useresolvevaluewithplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.useresolvevaluewithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useworkspace.html
+++ b/v8.5.0/docs/sdk-ui.useworkspace.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.useworkspacestrict.html
+++ b/v8.5.0/docs/sdk-ui.useworkspacestrict.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.valueformatter.html
+++ b/v8.5.0/docs/sdk-ui.valueformatter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.valueormultivalueplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.valueormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.valueorplaceholder.html
+++ b/v8.5.0/docs/sdk-ui.valueorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.valuesorplaceholders.html
+++ b/v8.5.0/docs/sdk-ui.valuesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.viselementtype.html
+++ b/v8.5.0/docs/sdk-ui.viselementtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.vistype.html
+++ b/v8.5.0/docs/sdk-ui.vistype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.withloadingresult.html
+++ b/v8.5.0/docs/sdk-ui.withloadingresult.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.workspaceprovider.html
+++ b/v8.5.0/docs/sdk-ui.workspaceprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/docs/sdk-ui.xirrtype.html
+++ b/v8.5.0/docs/sdk-ui.xirrtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/en/help.html
+++ b/v8.5.0/en/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/en/index.html
+++ b/v8.5.0/en/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/en/users.html
+++ b/v8.5.0/en/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/help.html
+++ b/v8.5.0/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/index.html
+++ b/v8.5.0/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.5.0/users.html
+++ b/v8.5.0/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.5.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/index.html
+++ b/v8.6.0/docs/index.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
+++ b/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror.cause.html
+++ b/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror.html
+++ b/v8.6.0/docs/sdk-backend-spi.analyticalbackenderror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.analyticalbackenderrortypes.html
+++ b/v8.6.0/docs/sdk-backend-spi.analyticalbackenderrortypes.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.analyticalbackendfactory.html
+++ b/v8.6.0/docs/sdk-backend-spi.analyticalbackendfactory.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.attributedescriptorlocalid.html
+++ b/v8.6.0/docs/sdk-backend-spi.attributedescriptorlocalid.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.attributedescriptorname.html
+++ b/v8.6.0/docs/sdk-backend-spi.attributedescriptorname.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.authenticationflow.html
+++ b/v8.6.0/docs/sdk-backend-spi.authenticationflow.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.catalogitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.catalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.catalogitemmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.catalogitemmetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.catalogitemtype.html
+++ b/v8.6.0/docs/sdk-backend-spi.catalogitemtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.datacolumntype.html
+++ b/v8.6.0/docs/sdk-backend-spi.datacolumntype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.datasetloadstatus.html
+++ b/v8.6.0/docs/sdk-backend-spi.datasetloadstatus.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.datatoolargeerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.datatoolargeerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.datavalue.html
+++ b/v8.6.0/docs/sdk-backend-spi.datavalue.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.errorconverter.html
+++ b/v8.6.0/docs/sdk-backend-spi.errorconverter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.filterwithresolvableelements.html
+++ b/v8.6.0/docs/sdk-backend-spi.filterwithresolvableelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.groupablecatalogitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.groupablecatalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.html
+++ b/v8.6.0/docs/sdk-backend-spi.html
@@ -289,7 +289,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.config.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.organization.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.organization.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalbackendconfig.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalbackendconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.users.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.users.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelement.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelement.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelement.title.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelement.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelement.uri.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelement.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.iattributemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticatedprincipal.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticatedprincipal.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationcontext.backend.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationcontext.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationcontext.client.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationcontext.client.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationcontext.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationcontext.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
+++ b/v8.6.0/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.hastypescopedidentifiers.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.hastypescopedidentifiers.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsexplain.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsexplain.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
+++ b/v8.6.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogattribute.attribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogattribute.displayforms.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogattribute.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogattribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogattribute.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogattribute.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogattribute.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdateattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogdatedataset.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogfact.fact.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogfact.fact.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogfact.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogfact.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogfact.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icataloggroup.html
+++ b/v8.6.0/docs/sdk-backend-spi.icataloggroup.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icataloggroup.tag.html
+++ b/v8.6.0/docs/sdk-backend-spi.icataloggroup.tag.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icataloggroup.title.html
+++ b/v8.6.0/docs/sdk-backend-spi.icataloggroup.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogitembase.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogitembase.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogitembase.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogitembase.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogmeasure.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogmeasure.measure.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogmeasure.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.icatalogmeasure.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.icatalogmeasure.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idashboardmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.idashboardmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idashboardmetadataobject.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.idashboardmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatacolumn.column.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatacolumn.column.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatacolumn.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatacolumn.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataheader.columns.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataheader.columns.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataheader.headerrowindex.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataheader.headerrowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataset.dataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataset.dataset.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataset.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.created.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.created.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.owner.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.owner.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.status.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetloadinfo.status.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetmetadataobject.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetuser.fullname.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetuser.fullname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetuser.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatasetuser.login.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatasetuser.login.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.count.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.data.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.data.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.definition.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.equals.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.fingerprint.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.headeritems.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.headeritems.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.offset.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.result.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.result.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.totalcount.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.totalcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.totals.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.totals.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idataview.warnings.html
+++ b/v8.6.0/docs/sdk-backend-spi.idataview.warnings.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idimensiondescriptor.headers.html
+++ b/v8.6.0/docs/sdk-backend-spi.idimensiondescriptor.headers.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idimensiondescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.idimensiondescriptor.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.idimensionitemdescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.idimensionitemdescriptor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.query.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.withdatefilters.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.withdatefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.withlimit.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.withmeasures.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.withmeasures.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.withoffset.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsquery.withoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryattributefilter.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryattributefilter.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryfactory.forfilter.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryfactory.forfilter.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryfactory.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.order.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.order.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ielementsqueryresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.ielementsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
@@ -36,7 +36,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.foritems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.foritems.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionfactory.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.definition.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.dimensions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.dimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.equals.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.export.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.export.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.readall.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.readall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.readwindow.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.readwindow.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexecutionresult.transform.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexecutionresult.transform.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportconfig.format.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportconfig.format.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportconfig.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportconfig.showfilters.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportconfig.showfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportconfig.title.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportconfig.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iexportresult.uri.html
+++ b/v8.6.0/docs/sdk-backend-spi.iexportresult.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ifactmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.ifactmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ifactmetadataobject.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.ifactmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.html
+++ b/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.query.html
+++ b/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.withlimit.html
+++ b/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.withoffset.html
+++ b/v8.6.0/docs/sdk-backend-spi.ifilterelementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.igetinsightoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.igetinsightoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.igetinsightoptions.loaduserdata.html
+++ b/v8.6.0/docs/sdk-backend-spi.igetinsightoptions.loaduserdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
+++ b/v8.6.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
+++ b/v8.6.0/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.igroupablecatalogitembase.html
+++ b/v8.6.0/docs/sdk-backend-spi.igroupablecatalogitembase.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightreferences.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightreferences.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightreferencing.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightreferencing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.loaduserdata.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.loaduserdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iinsightsqueryresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.iinsightsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasuredescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasuredescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasureexpressiontoken.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasureexpressiontoken.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasuregroupdescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasuregroupdescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasuremetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasuremetadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasurereferencing.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasurereferencing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasurereferencing.insights.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasurereferencing.insights.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imeasurereferencing.measures.html
+++ b/v8.6.0/docs/sdk-backend-spi.imeasurereferencing.measures.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.imetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.imetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.insightordering.html
+++ b/v8.6.0/docs/sdk-backend-spi.insightordering.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.insightreferencetypes.html
+++ b/v8.6.0/docs/sdk-backend-spi.insightreferencetypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.html
+++ b/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
+++ b/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
+++ b/v8.6.0/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganization.getdescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganization.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganization.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganization.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganization.organizationid.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganization.organizationid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganization.securitysettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganization.securitysettings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganizationdescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganizationdescriptor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganizationdescriptor.id.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganizationdescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganizationdescriptor.title.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganizationdescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iorganizations.html
+++ b/v8.6.0/docs/sdk-backend-spi.iorganizations.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.all.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.all.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.allsorted.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.allsorted.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.goto.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.goto.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.items.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.limit.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.next.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.next.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.offset.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.offset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipagedresource.totalcount.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipagedresource.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.definition.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.equals.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.execute.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.execute.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
+++ b/v8.6.0/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultattributeheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultattributeheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultheader.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultmeasureheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultmeasureheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresulttotalheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresulttotalheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultwarning.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultwarning.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultwarning.message.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultwarning.message.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultwarning.parameters.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultwarning.parameters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iresultwarning.warningcode.html
+++ b/v8.6.0/docs/sdk-backend-spi.iresultwarning.warningcode.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isanalyticalbackenderror.html
+++ b/v8.6.0/docs/sdk-backend-spi.isanalyticalbackenderror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isattributedescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.isattributedescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isattributemetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.isattributemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iscatalogattribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.iscatalogattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iscatalogdatedataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.iscatalogdatedataset.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iscatalogfact.html
+++ b/v8.6.0/docs/sdk-backend-spi.iscatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iscatalogmeasure.html
+++ b/v8.6.0/docs/sdk-backend-spi.iscatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isdashboardmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.isdashboardmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isdatasetmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.isdatasetmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isdatatoolargeerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.isdatatoolargeerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isecuritysettingsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.isecuritysettingsservice.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
+++ b/v8.6.0/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
+++ b/v8.6.0/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iseparators.decimal.html
+++ b/v8.6.0/docs/sdk-backend-spi.iseparators.decimal.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iseparators.html
+++ b/v8.6.0/docs/sdk-backend-spi.iseparators.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iseparators.thousand.html
+++ b/v8.6.0/docs/sdk-backend-spi.iseparators.thousand.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enableapproxcount.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enableapproxcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablebulletchart.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablebulletchart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablecompanylogoinembeddedui.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablecompanylogoinembeddedui.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enabledatasampling.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enabledatasampling.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enabledrilledinsightexport.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enabledrilledinsightexport.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekdzooming.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekdzooming.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablemultipledates.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablemultipledates.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enablesectionheaders.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enablesectionheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.enableweekfilters.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.enableweekfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.html
@@ -113,7 +113,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.platformedition.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.platformedition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
+++ b/v8.6.0/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isfactmetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.isfactmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ismeasuredescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ismeasuredescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ismeasuremetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.ismeasuremetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
+++ b/v8.6.0/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ismetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.ismetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isnodataerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.isnodataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isnotauthenticated.html
+++ b/v8.6.0/docs/sdk-backend-spi.isnotauthenticated.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isnotimplemented.html
+++ b/v8.6.0/docs/sdk-backend-spi.isnotimplemented.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isnotsupported.html
+++ b/v8.6.0/docs/sdk-backend-spi.isnotsupported.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isprotecteddataerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.isprotecteddataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isresultattributeheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.isresultattributeheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isresultmeasureheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.isresultmeasureheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isresulttotalheader.html
+++ b/v8.6.0/docs/sdk-backend-spi.isresulttotalheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.istotaldescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.istotaldescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isunexpectederror.html
+++ b/v8.6.0/docs/sdk-backend-spi.isunexpectederror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isunexpectedresponseerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.isunexpectedresponseerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.isvariablemetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.isvariablemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itextexpressiontoken.html
+++ b/v8.6.0/docs/sdk-backend-spi.itextexpressiontoken.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itextexpressiontoken.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.itextexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itextexpressiontoken.value.html
+++ b/v8.6.0/docs/sdk-backend-spi.itextexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.analyticaldesigner.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.analyticaldesigner.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.button.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.button.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.chart.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.chart.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.dashboards.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.dashboards.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.kpi.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.kpi.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.modal.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.modal.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.palette.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.palette.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.table.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.table.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.tooltip.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.tooltip.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itheme.typography.html
+++ b/v8.6.0/docs/sdk-backend-spi.itheme.typography.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.axiscolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.axiscolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.gridcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.base.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.base.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.dark.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.dark.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.light.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecolorfamily.light.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemecomplementarypalette.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemekpi.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemekpi.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemekpi.value.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemekpi.value.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.complementary.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.complementary.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.error.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.error.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.info.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.info.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.primary.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.primary.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.success.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.success.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemepalette.warning.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemepalette.warning.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.gridcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetable.valuecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetable.valuecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetypography.font.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetypography.font.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetypography.fontbold.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetypography.fontbold.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemetypography.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemetypography.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemewidgettitle.color.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemewidgettitle.color.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemewidgettitle.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemewidgettitle.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
+++ b/v8.6.0/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itotaldescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.itotaldescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
+++ b/v8.6.0/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iuserservice.getuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.iuserservice.getuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iuserservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iuserservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iuserservice.settings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iuserservice.settings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iusersettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iusersettings.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iusersettings.locale.html
+++ b/v8.6.0/docs/sdk-backend-spi.iusersettings.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iusersettings.separators.html
+++ b/v8.6.0/docs/sdk-backend-spi.iusersettings.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iusersettings.userid.html
+++ b/v8.6.0/docs/sdk-backend-spi.iusersettings.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iusersettingsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iusersettingsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iuserworkspacesettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iuserworkspacesettings.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ivariablemetadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.ivariablemetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.ivariablemetadataobject.type.html
+++ b/v8.6.0/docs/sdk-backend-spi.ivariablemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceattributesservice.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalog.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalog.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedatasetsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedatasetsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.description.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.id.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.title.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacedescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacefactsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacefactsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasurereferencingobjects.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasurereferencingobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacepermissions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacepermissions.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacepermissionsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacepermissionsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesettings.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesettings.workspace.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesettings.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesettingsservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesettingsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.query.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.query.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryfactory.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryresult.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryresult.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryresult.search.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacesqueryresult.search.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspacestylingservice.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspacestylingservice.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.email.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.firstname.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.fullname.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.lastname.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.login.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.ref.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.uri.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceuser.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceusersquery.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceusersquery.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
+++ b/v8.6.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.metadataobject.html
+++ b/v8.6.0/docs/sdk-backend-spi.metadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.metadataobjectid.html
+++ b/v8.6.0/docs/sdk-backend-spi.metadataobjectid.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.nodataerror._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.nodataerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.nodataerror.dataview.html
+++ b/v8.6.0/docs/sdk-backend-spi.nodataerror.dataview.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.nodataerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.nodataerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notauthenticated._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.notauthenticated._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
+++ b/v8.6.0/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notauthenticated.html
+++ b/v8.6.0/docs/sdk-backend-spi.notauthenticated.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notauthenticatedhandler.html
+++ b/v8.6.0/docs/sdk-backend-spi.notauthenticatedhandler.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notimplemented._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.notimplemented._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notimplemented.html
+++ b/v8.6.0/docs/sdk-backend-spi.notimplemented.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notsupported._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.notsupported._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.notsupported.html
+++ b/v8.6.0/docs/sdk-backend-spi.notsupported.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.platformedition.html
+++ b/v8.6.0/docs/sdk-backend-spi.platformedition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.prepareexecution.html
+++ b/v8.6.0/docs/sdk-backend-spi.prepareexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.protecteddataerror._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.protecteddataerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.protecteddataerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.protecteddataerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.resultheadername.html
+++ b/v8.6.0/docs/sdk-backend-spi.resultheadername.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.supportedinsightreferencetypes.html
+++ b/v8.6.0/docs/sdk-backend-spi.supportedinsightreferencetypes.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.themecolor.html
+++ b/v8.6.0/docs/sdk-backend-spi.themecolor.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.themefonturi.html
+++ b/v8.6.0/docs/sdk-backend-spi.themefonturi.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.unexpectederror._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.unexpectederror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.unexpectederror.html
+++ b/v8.6.0/docs/sdk-backend-spi.unexpectederror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
+++ b/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror.html
+++ b/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
+++ b/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
+++ b/v8.6.0/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.validationcontext.html
+++ b/v8.6.0/docs/sdk-backend-spi.validationcontext.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-backend-spi.workspacepermission.html
+++ b/v8.6.0/docs/sdk-backend-spi.workspacepermission.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.absolutedatefiltervalues.html
+++ b/v8.6.0/docs/sdk-model.absolutedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.alltimegranularity.html
+++ b/v8.6.0/docs/sdk-model.alltimegranularity.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.anyattribute.html
+++ b/v8.6.0/docs/sdk-model.anyattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.anybucket.html
+++ b/v8.6.0/docs/sdk-model.anybucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.anymeasure.html
+++ b/v8.6.0/docs/sdk-model.anymeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.applyratiorule.html
+++ b/v8.6.0/docs/sdk-model.applyratiorule.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.areobjrefsequal.html
+++ b/v8.6.0/docs/sdk-model.areobjrefsequal.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.operands.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.operands.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.operator.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasurebuilder.operator.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasurebuilderinput.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.arithmeticmeasureoperator.html
+++ b/v8.6.0/docs/sdk-model.arithmeticmeasureoperator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributealias.html
+++ b/v8.6.0/docs/sdk-model.attributealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.alias.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.build.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.build.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.defaultlocalid.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.displayform.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.localid.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilder.noalias.html
+++ b/v8.6.0/docs/sdk-model.attributebuilder.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributebuilderinput.html
+++ b/v8.6.0/docs/sdk-model.attributebuilderinput.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributedisplayformref.html
+++ b/v8.6.0/docs/sdk-model.attributedisplayformref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributeidentifier.html
+++ b/v8.6.0/docs/sdk-model.attributeidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributeinbucket.html
+++ b/v8.6.0/docs/sdk-model.attributeinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributelocalid.html
+++ b/v8.6.0/docs/sdk-model.attributelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributelocatorelement.html
+++ b/v8.6.0/docs/sdk-model.attributelocatorelement.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributelocatoridentifier.html
+++ b/v8.6.0/docs/sdk-model.attributelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributemodifications.html
+++ b/v8.6.0/docs/sdk-model.attributemodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributepredicate.html
+++ b/v8.6.0/docs/sdk-model.attributepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributesfind.html
+++ b/v8.6.0/docs/sdk-model.attributesfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.attributeuri.html
+++ b/v8.6.0/docs/sdk-model.attributeuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketattribute.html
+++ b/v8.6.0/docs/sdk-model.bucketattribute.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketattributeindex.html
+++ b/v8.6.0/docs/sdk-model.bucketattributeindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketattributes.html
+++ b/v8.6.0/docs/sdk-model.bucketattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketisempty.html
+++ b/v8.6.0/docs/sdk-model.bucketisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketitemlocalid.html
+++ b/v8.6.0/docs/sdk-model.bucketitemlocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketitemmodifications.html
+++ b/v8.6.0/docs/sdk-model.bucketitemmodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketitemreduce.html
+++ b/v8.6.0/docs/sdk-model.bucketitemreduce.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketitemreducer.html
+++ b/v8.6.0/docs/sdk-model.bucketitemreducer.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketitems.html
+++ b/v8.6.0/docs/sdk-model.bucketitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketmeasure.html
+++ b/v8.6.0/docs/sdk-model.bucketmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketmeasureindex.html
+++ b/v8.6.0/docs/sdk-model.bucketmeasureindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketmeasures.html
+++ b/v8.6.0/docs/sdk-model.bucketmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketmodifyitems.html
+++ b/v8.6.0/docs/sdk-model.bucketmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketpredicate.html
+++ b/v8.6.0/docs/sdk-model.bucketpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsattributes.html
+++ b/v8.6.0/docs/sdk-model.bucketsattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsbyid.html
+++ b/v8.6.0/docs/sdk-model.bucketsbyid.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsettotals.html
+++ b/v8.6.0/docs/sdk-model.bucketsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsfind.html
+++ b/v8.6.0/docs/sdk-model.bucketsfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsfindattribute.html
+++ b/v8.6.0/docs/sdk-model.bucketsfindattribute.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsfindmeasure.html
+++ b/v8.6.0/docs/sdk-model.bucketsfindmeasure.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsisempty.html
+++ b/v8.6.0/docs/sdk-model.bucketsisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsitems.html
+++ b/v8.6.0/docs/sdk-model.bucketsitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsmeasures.html
+++ b/v8.6.0/docs/sdk-model.bucketsmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsmodifyitem.html
+++ b/v8.6.0/docs/sdk-model.bucketsmodifyitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketsreduceitem.html
+++ b/v8.6.0/docs/sdk-model.bucketsreduceitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.bucketstotals.html
+++ b/v8.6.0/docs/sdk-model.bucketstotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.buckettotals.html
+++ b/v8.6.0/docs/sdk-model.buckettotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.colorpaletteitemtorgb.html
+++ b/v8.6.0/docs/sdk-model.colorpaletteitemtorgb.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.colorpalettetocolors.html
+++ b/v8.6.0/docs/sdk-model.colorpalettetocolors.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.comparatordirection.html
+++ b/v8.6.0/docs/sdk-model.comparatordirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.comparisonconditionoperator.html
+++ b/v8.6.0/docs/sdk-model.comparisonconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.computeratiorule.html
+++ b/v8.6.0/docs/sdk-model.computeratiorule.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dateattributegranularity.html
+++ b/v8.6.0/docs/sdk-model.dateattributegranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dategranularity.html
+++ b/v8.6.0/docs/sdk-model.dategranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defaultdimensionsgenerator.html
+++ b/v8.6.0/docs/sdk-model.defaultdimensionsgenerator.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.deffingerprint.html
+++ b/v8.6.0/docs/sdk-model.deffingerprint.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defsetdimensions.html
+++ b/v8.6.0/docs/sdk-model.defsetdimensions.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defsetexecconfig.html
+++ b/v8.6.0/docs/sdk-model.defsetexecconfig.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defsetpostprocessing.html
+++ b/v8.6.0/docs/sdk-model.defsetpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defsetsorts.html
+++ b/v8.6.0/docs/sdk-model.defsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.deftotals.html
+++ b/v8.6.0/docs/sdk-model.deftotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defwithdateformat.html
+++ b/v8.6.0/docs/sdk-model.defwithdateformat.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defwithdimensions.html
+++ b/v8.6.0/docs/sdk-model.defwithdimensions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defwithexecconfig.html
+++ b/v8.6.0/docs/sdk-model.defwithexecconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defwithfilters.html
+++ b/v8.6.0/docs/sdk-model.defwithfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defwithpostprocessing.html
+++ b/v8.6.0/docs/sdk-model.defwithpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.defwithsorting.html
+++ b/v8.6.0/docs/sdk-model.defwithsorting.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.deserializeobjref.html
+++ b/v8.6.0/docs/sdk-model.deserializeobjref.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dimensiongenerator.html
+++ b/v8.6.0/docs/sdk-model.dimensiongenerator.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dimensionitem.html
+++ b/v8.6.0/docs/sdk-model.dimensionitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dimensionsettotals.html
+++ b/v8.6.0/docs/sdk-model.dimensionsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dimensionsfinditem.html
+++ b/v8.6.0/docs/sdk-model.dimensionsfinditem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.dimensiontotals.html
+++ b/v8.6.0/docs/sdk-model.dimensiontotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.disablecomputeratio.html
+++ b/v8.6.0/docs/sdk-model.disablecomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.emptydef.html
+++ b/v8.6.0/docs/sdk-model.emptydef.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.factorynotationfor.html
+++ b/v8.6.0/docs/sdk-model.factorynotationfor.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.filterattributeelements.html
+++ b/v8.6.0/docs/sdk-model.filterattributeelements.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.filterattributeelements_1.html
+++ b/v8.6.0/docs/sdk-model.filterattributeelements_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.filterisempty.html
+++ b/v8.6.0/docs/sdk-model.filterisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.filtermeasureref.html
+++ b/v8.6.0/docs/sdk-model.filtermeasureref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.filterobjref.html
+++ b/v8.6.0/docs/sdk-model.filterobjref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.filterobjref_1.html
+++ b/v8.6.0/docs/sdk-model.filterobjref_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.guidtype.html
+++ b/v8.6.0/docs/sdk-model.guidtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.html
+++ b/v8.6.0/docs/sdk-model.html
@@ -439,7 +439,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
+++ b/v8.6.0/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iabsolutedatefilter.html
+++ b/v8.6.0/docs/sdk-model.iabsolutedatefilter.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iabsolutedatefiltervalues.from.html
+++ b/v8.6.0/docs/sdk-model.iabsolutedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iabsolutedatefiltervalues.html
+++ b/v8.6.0/docs/sdk-model.iabsolutedatefiltervalues.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iabsolutedatefiltervalues.to.html
+++ b/v8.6.0/docs/sdk-model.iabsolutedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
+++ b/v8.6.0/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iarithmeticmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.iarithmeticmeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattribute.attribute.html
+++ b/v8.6.0/docs/sdk-model.iattribute.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattribute.html
+++ b/v8.6.0/docs/sdk-model.iattribute.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributeelements.html
+++ b/v8.6.0/docs/sdk-model.iattributeelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributeelementsbyref.html
+++ b/v8.6.0/docs/sdk-model.iattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributeelementsbyref.uris.html
+++ b/v8.6.0/docs/sdk-model.iattributeelementsbyref.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributeelementsbyvalue.html
+++ b/v8.6.0/docs/sdk-model.iattributeelementsbyvalue.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributeelementsbyvalue.values.html
+++ b/v8.6.0/docs/sdk-model.iattributeelementsbyvalue.values.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributefilter.html
+++ b/v8.6.0/docs/sdk-model.iattributefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
+++ b/v8.6.0/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributelocatoritem.html
+++ b/v8.6.0/docs/sdk-model.iattributelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributeormeasure.html
+++ b/v8.6.0/docs/sdk-model.iattributeormeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributesortitem.attributesortitem.html
+++ b/v8.6.0/docs/sdk-model.iattributesortitem.attributesortitem.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iattributesortitem.html
+++ b/v8.6.0/docs/sdk-model.iattributesortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditable.html
+++ b/v8.6.0/docs/sdk-model.iauditable.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditabledates.created.html
+++ b/v8.6.0/docs/sdk-model.iauditabledates.created.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditabledates.html
+++ b/v8.6.0/docs/sdk-model.iauditabledates.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditabledates.updated.html
+++ b/v8.6.0/docs/sdk-model.iauditabledates.updated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditableusers.createdby.html
+++ b/v8.6.0/docs/sdk-model.iauditableusers.createdby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditableusers.html
+++ b/v8.6.0/docs/sdk-model.iauditableusers.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iauditableusers.updatedby.html
+++ b/v8.6.0/docs/sdk-model.iauditableusers.updatedby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ibucket.html
+++ b/v8.6.0/docs/sdk-model.ibucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ibucket.items.html
+++ b/v8.6.0/docs/sdk-model.ibucket.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ibucket.localidentifier.html
+++ b/v8.6.0/docs/sdk-model.ibucket.localidentifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ibucket.totals.html
+++ b/v8.6.0/docs/sdk-model.ibucket.totals.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolor.html
+++ b/v8.6.0/docs/sdk-model.icolor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorfrompalette.html
+++ b/v8.6.0/docs/sdk-model.icolorfrompalette.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorfrompalette.type.html
+++ b/v8.6.0/docs/sdk-model.icolorfrompalette.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorfrompalette.value.html
+++ b/v8.6.0/docs/sdk-model.icolorfrompalette.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolormappingitem.color.html
+++ b/v8.6.0/docs/sdk-model.icolormappingitem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolormappingitem.html
+++ b/v8.6.0/docs/sdk-model.icolormappingitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolormappingitem.id.html
+++ b/v8.6.0/docs/sdk-model.icolormappingitem.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorpalette.html
+++ b/v8.6.0/docs/sdk-model.icolorpalette.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorpaletteitem.fill.html
+++ b/v8.6.0/docs/sdk-model.icolorpaletteitem.fill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorpaletteitem.guid.html
+++ b/v8.6.0/docs/sdk-model.icolorpaletteitem.guid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icolorpaletteitem.html
+++ b/v8.6.0/docs/sdk-model.icolorpaletteitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icomparator.html
+++ b/v8.6.0/docs/sdk-model.icomparator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icomparisoncondition.comparison.html
+++ b/v8.6.0/docs/sdk-model.icomparisoncondition.comparison.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.icomparisoncondition.html
+++ b/v8.6.0/docs/sdk-model.icomparisoncondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idatefilter.html
+++ b/v8.6.0/docs/sdk-model.idatefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.identifier.html
+++ b/v8.6.0/docs/sdk-model.identifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.identifierref.html
+++ b/v8.6.0/docs/sdk-model.identifierref.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idimension.html
+++ b/v8.6.0/docs/sdk-model.idimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idimension.itemidentifiers.html
+++ b/v8.6.0/docs/sdk-model.idimension.itemidentifiers.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idimension.totals.html
+++ b/v8.6.0/docs/sdk-model.idimension.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idmatchattribute.html
+++ b/v8.6.0/docs/sdk-model.idmatchattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idmatchbucket.html
+++ b/v8.6.0/docs/sdk-model.idmatchbucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idmatchmeasure.html
+++ b/v8.6.0/docs/sdk-model.idmatchmeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.idref.html
+++ b/v8.6.0/docs/sdk-model.idref.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
+++ b/v8.6.0/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutionconfig.html
+++ b/v8.6.0/docs/sdk-model.iexecutionconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.attributes.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.attributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.buckets.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.buckets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.dimensions.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.dimensions.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.executionconfig.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.executionconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.filters.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.measures.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.postprocessing.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.postprocessing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.sortby.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iexecutiondefinition.workspace.html
+++ b/v8.6.0/docs/sdk-model.iexecutiondefinition.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ifilter.html
+++ b/v8.6.0/docs/sdk-model.ifilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iinsight.html
+++ b/v8.6.0/docs/sdk-model.iinsight.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iinsightdefinition.html
+++ b/v8.6.0/docs/sdk-model.iinsightdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ilocatoritem.html
+++ b/v8.6.0/docs/sdk-model.ilocatoritem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasure.html
+++ b/v8.6.0/docs/sdk-model.imeasure.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasure.measure.html
+++ b/v8.6.0/docs/sdk-model.imeasure.measure.html
@@ -24,7 +24,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.imeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuredefinition.measuredefinition.html
+++ b/v8.6.0/docs/sdk-model.imeasuredefinition.measuredefinition.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuredefinitiontype.html
+++ b/v8.6.0/docs/sdk-model.imeasuredefinitiontype.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasurefilter.html
+++ b/v8.6.0/docs/sdk-model.imeasurefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasurelocatoritem.html
+++ b/v8.6.0/docs/sdk-model.imeasurelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
+++ b/v8.6.0/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuresortitem.html
+++ b/v8.6.0/docs/sdk-model.imeasuresortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuresortitem.measuresortitem.html
+++ b/v8.6.0/docs/sdk-model.imeasuresortitem.measuresortitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuretitle.html
+++ b/v8.6.0/docs/sdk-model.imeasuretitle.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasuretitle.measure.html
+++ b/v8.6.0/docs/sdk-model.imeasuretitle.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasurevaluefilter.html
+++ b/v8.6.0/docs/sdk-model.imeasurevaluefilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
+++ b/v8.6.0/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.inegativeattributefilter.html
+++ b/v8.6.0/docs/sdk-model.inegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
+++ b/v8.6.0/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightattributes.html
+++ b/v8.6.0/docs/sdk-model.insightattributes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightbucket.html
+++ b/v8.6.0/docs/sdk-model.insightbucket.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightbuckets.html
+++ b/v8.6.0/docs/sdk-model.insightbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightcreated.html
+++ b/v8.6.0/docs/sdk-model.insightcreated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightcreatedby.html
+++ b/v8.6.0/docs/sdk-model.insightcreatedby.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightdisplayformusage.html
+++ b/v8.6.0/docs/sdk-model.insightdisplayformusage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightfilters.html
+++ b/v8.6.0/docs/sdk-model.insightfilters.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighthasattributes.html
+++ b/v8.6.0/docs/sdk-model.insighthasattributes.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighthasdatadefined.html
+++ b/v8.6.0/docs/sdk-model.insighthasdatadefined.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighthasmeasures.html
+++ b/v8.6.0/docs/sdk-model.insighthasmeasures.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightid.html
+++ b/v8.6.0/docs/sdk-model.insightid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightislocked.html
+++ b/v8.6.0/docs/sdk-model.insightislocked.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightitems.html
+++ b/v8.6.0/docs/sdk-model.insightitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightmeasures.html
+++ b/v8.6.0/docs/sdk-model.insightmeasures.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightmodifyitems.html
+++ b/v8.6.0/docs/sdk-model.insightmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightproperties.html
+++ b/v8.6.0/docs/sdk-model.insightproperties.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightreduceitems.html
+++ b/v8.6.0/docs/sdk-model.insightreduceitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightref.html
+++ b/v8.6.0/docs/sdk-model.insightref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightsanitize.html
+++ b/v8.6.0/docs/sdk-model.insightsanitize.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightsetbuckets.html
+++ b/v8.6.0/docs/sdk-model.insightsetbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightsetfilters.html
+++ b/v8.6.0/docs/sdk-model.insightsetfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightsetproperties.html
+++ b/v8.6.0/docs/sdk-model.insightsetproperties.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightsetsorts.html
+++ b/v8.6.0/docs/sdk-model.insightsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightsorts.html
+++ b/v8.6.0/docs/sdk-model.insightsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighttags.html
+++ b/v8.6.0/docs/sdk-model.insighttags.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighttitle.html
+++ b/v8.6.0/docs/sdk-model.insighttitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighttotals.html
+++ b/v8.6.0/docs/sdk-model.insighttotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightupdated.html
+++ b/v8.6.0/docs/sdk-model.insightupdated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insightupdatedby.html
+++ b/v8.6.0/docs/sdk-model.insightupdatedby.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.insighturi.html
+++ b/v8.6.0/docs/sdk-model.insighturi.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.inullablefilter.html
+++ b/v8.6.0/docs/sdk-model.inullablefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipopmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.ipopmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipositiveattributefilter.html
+++ b/v8.6.0/docs/sdk-model.ipositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
+++ b/v8.6.0/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipostprocessing.dateformat.html
+++ b/v8.6.0/docs/sdk-model.ipostprocessing.dateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipostprocessing.html
+++ b/v8.6.0/docs/sdk-model.ipostprocessing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperioddatedataset.dataset.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperioddatedataset.dataset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperioddatedataset.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperioddatedataset.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperioddatedatasetsimple.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperioddatedatasetsimple.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperiodmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperiodmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
+++ b/v8.6.0/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irangecondition.html
+++ b/v8.6.0/docs/sdk-model.irangecondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irangecondition.range.html
+++ b/v8.6.0/docs/sdk-model.irangecondition.range.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irankingfilter.html
+++ b/v8.6.0/docs/sdk-model.irankingfilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irankingfilter.rankingfilter.html
+++ b/v8.6.0/docs/sdk-model.irankingfilter.rankingfilter.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irelativedatefilter.html
+++ b/v8.6.0/docs/sdk-model.irelativedatefilter.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irelativedatefiltervalues.from.html
+++ b/v8.6.0/docs/sdk-model.irelativedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irelativedatefiltervalues.granularity.html
+++ b/v8.6.0/docs/sdk-model.irelativedatefiltervalues.granularity.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irelativedatefiltervalues.html
+++ b/v8.6.0/docs/sdk-model.irelativedatefiltervalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irelativedatefiltervalues.to.html
+++ b/v8.6.0/docs/sdk-model.irelativedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolor.html
+++ b/v8.6.0/docs/sdk-model.irgbcolor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolor.type.html
+++ b/v8.6.0/docs/sdk-model.irgbcolor.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolor.value.html
+++ b/v8.6.0/docs/sdk-model.irgbcolor.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolorvalue.b.html
+++ b/v8.6.0/docs/sdk-model.irgbcolorvalue.b.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolorvalue.g.html
+++ b/v8.6.0/docs/sdk-model.irgbcolorvalue.g.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolorvalue.html
+++ b/v8.6.0/docs/sdk-model.irgbcolorvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.irgbcolorvalue.r.html
+++ b/v8.6.0/docs/sdk-model.irgbcolorvalue.r.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isabsolutedatefilter.html
+++ b/v8.6.0/docs/sdk-model.isabsolutedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isadhocmeasure.html
+++ b/v8.6.0/docs/sdk-model.isadhocmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isalltimedatefilter.html
+++ b/v8.6.0/docs/sdk-model.isalltimedatefilter.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isarithmeticmeasure.html
+++ b/v8.6.0/docs/sdk-model.isarithmeticmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isarithmeticmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.isarithmeticmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattribute.html
+++ b/v8.6.0/docs/sdk-model.isattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattributeareasort.html
+++ b/v8.6.0/docs/sdk-model.isattributeareasort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattributeelementsbyref.html
+++ b/v8.6.0/docs/sdk-model.isattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattributeelementsbyvalue.html
+++ b/v8.6.0/docs/sdk-model.isattributeelementsbyvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattributefilter.html
+++ b/v8.6.0/docs/sdk-model.isattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattributelocator.html
+++ b/v8.6.0/docs/sdk-model.isattributelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isattributesort.html
+++ b/v8.6.0/docs/sdk-model.isattributesort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isbucket.html
+++ b/v8.6.0/docs/sdk-model.isbucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iscolorfrompalette.html
+++ b/v8.6.0/docs/sdk-model.iscolorfrompalette.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iscomparisoncondition.html
+++ b/v8.6.0/docs/sdk-model.iscomparisoncondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iscomparisonconditionoperator.html
+++ b/v8.6.0/docs/sdk-model.iscomparisonconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isdatefilter.html
+++ b/v8.6.0/docs/sdk-model.isdatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isdimension.html
+++ b/v8.6.0/docs/sdk-model.isdimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isfilter.html
+++ b/v8.6.0/docs/sdk-model.isfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isidentifierref.html
+++ b/v8.6.0/docs/sdk-model.isidentifierref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isinsight.html
+++ b/v8.6.0/docs/sdk-model.isinsight.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.islocalidref.html
+++ b/v8.6.0/docs/sdk-model.islocalidref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ismeasure.html
+++ b/v8.6.0/docs/sdk-model.ismeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ismeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.ismeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ismeasureformatinpercent.html
+++ b/v8.6.0/docs/sdk-model.ismeasureformatinpercent.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ismeasurelocator.html
+++ b/v8.6.0/docs/sdk-model.ismeasurelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ismeasuresort.html
+++ b/v8.6.0/docs/sdk-model.ismeasuresort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ismeasurevaluefilter.html
+++ b/v8.6.0/docs/sdk-model.ismeasurevaluefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isnegativeattributefilter.html
+++ b/v8.6.0/docs/sdk-model.isnegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isobjref.html
+++ b/v8.6.0/docs/sdk-model.isobjref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isortitem.html
+++ b/v8.6.0/docs/sdk-model.isortitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ispopmeasure.html
+++ b/v8.6.0/docs/sdk-model.ispopmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ispopmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.ispopmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ispositiveattributefilter.html
+++ b/v8.6.0/docs/sdk-model.ispositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ispreviousperiodmeasure.html
+++ b/v8.6.0/docs/sdk-model.ispreviousperiodmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ispreviousperiodmeasuredefinition.html
+++ b/v8.6.0/docs/sdk-model.ispreviousperiodmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.israngecondition.html
+++ b/v8.6.0/docs/sdk-model.israngecondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.israngeconditionoperator.html
+++ b/v8.6.0/docs/sdk-model.israngeconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isrankingfilter.html
+++ b/v8.6.0/docs/sdk-model.isrankingfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isrelativedatefilter.html
+++ b/v8.6.0/docs/sdk-model.isrelativedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isrgbcolor.html
+++ b/v8.6.0/docs/sdk-model.isrgbcolor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.issimplemeasure.html
+++ b/v8.6.0/docs/sdk-model.issimplemeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.istotal.html
+++ b/v8.6.0/docs/sdk-model.istotal.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.isuriref.html
+++ b/v8.6.0/docs/sdk-model.isuriref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.itemindimension.html
+++ b/v8.6.0/docs/sdk-model.itemindimension.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.itotal.alias.html
+++ b/v8.6.0/docs/sdk-model.itotal.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.itotal.attributeidentifier.html
+++ b/v8.6.0/docs/sdk-model.itotal.attributeidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.itotal.html
+++ b/v8.6.0/docs/sdk-model.itotal.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.itotal.measureidentifier.html
+++ b/v8.6.0/docs/sdk-model.itotal.measureidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.itotal.type.html
+++ b/v8.6.0/docs/sdk-model.itotal.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.email.html
+++ b/v8.6.0/docs/sdk-model.iuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.firstname.html
+++ b/v8.6.0/docs/sdk-model.iuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.fullname.html
+++ b/v8.6.0/docs/sdk-model.iuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.html
+++ b/v8.6.0/docs/sdk-model.iuser.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.lastname.html
+++ b/v8.6.0/docs/sdk-model.iuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.login.html
+++ b/v8.6.0/docs/sdk-model.iuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.iuser.ref.html
+++ b/v8.6.0/docs/sdk-model.iuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ivisualizationclass.html
+++ b/v8.6.0/docs/sdk-model.ivisualizationclass.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.ivisualizationclass.visualizationclass.html
+++ b/v8.6.0/docs/sdk-model.ivisualizationclass.visualizationclass.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.localidref.html
+++ b/v8.6.0/docs/sdk-model.localidref.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureaggregation.html
+++ b/v8.6.0/docs/sdk-model.measureaggregation.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurealias.html
+++ b/v8.6.0/docs/sdk-model.measurealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurearithmeticoperands.html
+++ b/v8.6.0/docs/sdk-model.measurearithmeticoperands.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurearithmeticoperands_1.html
+++ b/v8.6.0/docs/sdk-model.measurearithmeticoperands_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurearithmeticoperator.html
+++ b/v8.6.0/docs/sdk-model.measurearithmeticoperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurearithmeticoperator_1.html
+++ b/v8.6.0/docs/sdk-model.measurearithmeticoperator_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.aggregation.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.aggregation.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.builddefinition.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.defaultaggregation.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.defaultaggregation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.filters.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.generatelocalid.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.measureitem.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.measureitem.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.nofilters.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.nofilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.noratio.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.noratio.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilder.ratio.html
+++ b/v8.6.0/docs/sdk-model.measurebuilder.ratio.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.alias.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.build.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.build.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.builddefinition.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.builddefinition.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.customlocalid.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.customlocalid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.defaultformat.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.defaultformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.defaultlocalid.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.format.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.format.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.generatelocalid.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.generatelocalid.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.initializefromexisting.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.initializefromexisting.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.localid.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.noalias.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.notitle.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.notitle.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurebuilderbase.title.html
+++ b/v8.6.0/docs/sdk-model.measurebuilderbase.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measuredoescomputeratio.html
+++ b/v8.6.0/docs/sdk-model.measuredoescomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureenvelope.html
+++ b/v8.6.0/docs/sdk-model.measureenvelope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurefilters.html
+++ b/v8.6.0/docs/sdk-model.measurefilters.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureformat.html
+++ b/v8.6.0/docs/sdk-model.measureformat.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measuregroupidentifier.html
+++ b/v8.6.0/docs/sdk-model.measuregroupidentifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureidentifier.html
+++ b/v8.6.0/docs/sdk-model.measureidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureinbucket.html
+++ b/v8.6.0/docs/sdk-model.measureinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureitem.html
+++ b/v8.6.0/docs/sdk-model.measureitem.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureitem_1.html
+++ b/v8.6.0/docs/sdk-model.measureitem_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurelocalid.html
+++ b/v8.6.0/docs/sdk-model.measurelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurelocatoridentifier.html
+++ b/v8.6.0/docs/sdk-model.measurelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measuremasteridentifier.html
+++ b/v8.6.0/docs/sdk-model.measuremasteridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measuremasteridentifier_1.html
+++ b/v8.6.0/docs/sdk-model.measuremasteridentifier_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measuremodifications.html
+++ b/v8.6.0/docs/sdk-model.measuremodifications.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureorlocalid.html
+++ b/v8.6.0/docs/sdk-model.measureorlocalid.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurepopattribute.html
+++ b/v8.6.0/docs/sdk-model.measurepopattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurepopattribute_1.html
+++ b/v8.6.0/docs/sdk-model.measurepopattribute_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurepredicate.html
+++ b/v8.6.0/docs/sdk-model.measurepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurepreviousperioddatedatasets.html
+++ b/v8.6.0/docs/sdk-model.measurepreviousperioddatedatasets.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurepreviousperioddatedatasets_1.html
+++ b/v8.6.0/docs/sdk-model.measurepreviousperioddatedatasets_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measuretitle.html
+++ b/v8.6.0/docs/sdk-model.measuretitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measureuri.html
+++ b/v8.6.0/docs/sdk-model.measureuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurevaluefiltercondition.html
+++ b/v8.6.0/docs/sdk-model.measurevaluefiltercondition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurevaluefiltermeasure.html
+++ b/v8.6.0/docs/sdk-model.measurevaluefiltermeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.measurevaluefilteroperator.html
+++ b/v8.6.0/docs/sdk-model.measurevaluefilteroperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.modifyattribute.html
+++ b/v8.6.0/docs/sdk-model.modifyattribute.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.modifymeasure.html
+++ b/v8.6.0/docs/sdk-model.modifymeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.modifypopmeasure.html
+++ b/v8.6.0/docs/sdk-model.modifypopmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.modifypreviousperiodmeasure.html
+++ b/v8.6.0/docs/sdk-model.modifypreviousperiodmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.modifysimplemeasure.html
+++ b/v8.6.0/docs/sdk-model.modifysimplemeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newabsolutedatefilter.html
+++ b/v8.6.0/docs/sdk-model.newabsolutedatefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newalltimefilter.html
+++ b/v8.6.0/docs/sdk-model.newalltimefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newarithmeticmeasure.html
+++ b/v8.6.0/docs/sdk-model.newarithmeticmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newattribute.html
+++ b/v8.6.0/docs/sdk-model.newattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newattributeareasort.html
+++ b/v8.6.0/docs/sdk-model.newattributeareasort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newattributelocator.html
+++ b/v8.6.0/docs/sdk-model.newattributelocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newattributesort.html
+++ b/v8.6.0/docs/sdk-model.newattributesort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newbucket.html
+++ b/v8.6.0/docs/sdk-model.newbucket.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newdefforbuckets.html
+++ b/v8.6.0/docs/sdk-model.newdefforbuckets.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newdefforinsight.html
+++ b/v8.6.0/docs/sdk-model.newdefforinsight.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newdefforitems.html
+++ b/v8.6.0/docs/sdk-model.newdefforitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newdimension.html
+++ b/v8.6.0/docs/sdk-model.newdimension.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newmeasure.html
+++ b/v8.6.0/docs/sdk-model.newmeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newmeasuresort.html
+++ b/v8.6.0/docs/sdk-model.newmeasuresort.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newmeasurevaluefilter.html
+++ b/v8.6.0/docs/sdk-model.newmeasurevaluefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newmeasurevaluefilter_1.html
+++ b/v8.6.0/docs/sdk-model.newmeasurevaluefilter_1.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newnegativeattributefilter.html
+++ b/v8.6.0/docs/sdk-model.newnegativeattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newpopmeasure.html
+++ b/v8.6.0/docs/sdk-model.newpopmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newpositiveattributefilter.html
+++ b/v8.6.0/docs/sdk-model.newpositiveattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newpreviousperiodmeasure.html
+++ b/v8.6.0/docs/sdk-model.newpreviousperiodmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newrankingfilter.html
+++ b/v8.6.0/docs/sdk-model.newrankingfilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newrankingfilter_1.html
+++ b/v8.6.0/docs/sdk-model.newrankingfilter_1.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newrelativedatefilter.html
+++ b/v8.6.0/docs/sdk-model.newrelativedatefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newtotal.html
+++ b/v8.6.0/docs/sdk-model.newtotal.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.newtwodimensional.html
+++ b/v8.6.0/docs/sdk-model.newtwodimensional.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.objecttype.html
+++ b/v8.6.0/docs/sdk-model.objecttype.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.objref.html
+++ b/v8.6.0/docs/sdk-model.objref.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.objrefinscope.html
+++ b/v8.6.0/docs/sdk-model.objrefinscope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.popmeasurebuilder.builddefinition.html
+++ b/v8.6.0/docs/sdk-model.popmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.popmeasurebuilder.generatelocalid.html
+++ b/v8.6.0/docs/sdk-model.popmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.popmeasurebuilder.html
+++ b/v8.6.0/docs/sdk-model.popmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.popmeasurebuilder.mastermeasure.html
+++ b/v8.6.0/docs/sdk-model.popmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.popmeasurebuilder.popattribute.html
+++ b/v8.6.0/docs/sdk-model.popmeasurebuilder.popattribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.popmeasurebuilderinput.html
+++ b/v8.6.0/docs/sdk-model.popmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
+++ b/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
+++ b/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
+++ b/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.html
+++ b/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
+++ b/v8.6.0/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.previousperiodmeasurebuilderinput.html
+++ b/v8.6.0/docs/sdk-model.previousperiodmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.rangeconditionoperator.html
+++ b/v8.6.0/docs/sdk-model.rangeconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.rankingfilteroperator.html
+++ b/v8.6.0/docs/sdk-model.rankingfilteroperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.relativedatefiltervalues.html
+++ b/v8.6.0/docs/sdk-model.relativedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.rgbtype.html
+++ b/v8.6.0/docs/sdk-model.rgbtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.serializeobjref.html
+++ b/v8.6.0/docs/sdk-model.serializeobjref.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.sortdirection.html
+++ b/v8.6.0/docs/sdk-model.sortdirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.sortentityids.html
+++ b/v8.6.0/docs/sdk-model.sortentityids.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.sortmeasurelocators.html
+++ b/v8.6.0/docs/sdk-model.sortmeasurelocators.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.totalisnative.html
+++ b/v8.6.0/docs/sdk-model.totalisnative.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.totaltype.html
+++ b/v8.6.0/docs/sdk-model.totaltype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.uri.html
+++ b/v8.6.0/docs/sdk-model.uri.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.uriref.html
+++ b/v8.6.0/docs/sdk-model.uriref.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.userfullname.html
+++ b/v8.6.0/docs/sdk-model.userfullname.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.visclassid.html
+++ b/v8.6.0/docs/sdk-model.visclassid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.visclassuri.html
+++ b/v8.6.0/docs/sdk-model.visclassuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.visclassurl.html
+++ b/v8.6.0/docs/sdk-model.visclassurl.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-model.visualizationproperties.html
+++ b/v8.6.0/docs/sdk-model.visualizationproperties.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.areachart.html
+++ b/v8.6.0/docs/sdk-ui-charts.areachart.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.axisnameposition.html
+++ b/v8.6.0/docs/sdk-ui-charts.axisnameposition.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.barchart.html
+++ b/v8.6.0/docs/sdk-ui-charts.barchart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.bubblechart.html
+++ b/v8.6.0/docs/sdk-ui-charts.bubblechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.bulletchart.html
+++ b/v8.6.0/docs/sdk-ui-charts.bulletchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.chartaligntypes.html
+++ b/v8.6.0/docs/sdk-ui-charts.chartaligntypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.columnchart.html
+++ b/v8.6.0/docs/sdk-ui-charts.columnchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.combochart.html
+++ b/v8.6.0/docs/sdk-ui-charts.combochart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.donutchart.html
+++ b/v8.6.0/docs/sdk-ui-charts.donutchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.funnelchart.html
+++ b/v8.6.0/docs/sdk-ui-charts.funnelchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.headline.html
+++ b/v8.6.0/docs/sdk-ui-charts.headline.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.heatmap.html
+++ b/v8.6.0/docs/sdk-ui-charts.heatmap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.html
+++ b/v8.6.0/docs/sdk-ui-charts.html
@@ -164,7 +164,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iareachartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iareachartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.max.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.max.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.min.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.min.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.name.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.name.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.rotation.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.rotation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisconfig.visible.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisnameconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisnameconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisnameconfig.position.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisnameconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iaxisnameconfig.visible.html
+++ b/v8.6.0/docs/sdk-ui-charts.iaxisnameconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibarchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibarchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibubblechartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibubblechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibucketchartprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibucketchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibucketchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibucketchartprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibucketchartprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibucketchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ibulletchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ibulletchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartcallbacks.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartcallbacks.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.colormapping.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.colormapping.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.colorpalette.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.colorpalette.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.colors.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.colors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.datalabels.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.datalabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.datapoints.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.datapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.dualaxis.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.dualaxis.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.grid.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.grid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.html
@@ -111,7 +111,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.legend.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.legend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.legendlayout.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.legendlayout.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.separators.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.xaxis.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.xformat.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.xformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.xlabel.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.xlabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.yaxis.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.yformat.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.yformat.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.ylabel.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.ylabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartconfig.zoominsight.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartconfig.zoominsight.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartlimits.categories.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartlimits.categories.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartlimits.datapoints.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartlimits.datapoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartlimits.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartlimits.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ichartlimits.series.html
+++ b/v8.6.0/docs/sdk-ui-charts.ichartlimits.series.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icolumnchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.icolumnchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icombochartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.icombochartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icommonchartprops.config.html
+++ b/v8.6.0/docs/sdk-ui-charts.icommonchartprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icommonchartprops.execconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.icommonchartprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icommonchartprops.height.html
+++ b/v8.6.0/docs/sdk-ui-charts.icommonchartprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icommonchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.icommonchartprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.icommonchartprops.width.html
+++ b/v8.6.0/docs/sdk-ui-charts.icommonchartprops.width.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idatalabelsconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.idatalabelsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idatalabelsconfig.visible.html
+++ b/v8.6.0/docs/sdk-ui-charts.idatalabelsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idatalabelsvisible.html
+++ b/v8.6.0/docs/sdk-ui-charts.idatalabelsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idatapointsconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.idatapointsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idatapointsconfig.visible.html
+++ b/v8.6.0/docs/sdk-ui-charts.idatapointsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idatapointsvisible.html
+++ b/v8.6.0/docs/sdk-ui-charts.idatapointsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.idonutchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.idonutchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ifunnelchartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ifunnelchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.igridconfig.enabled.html
+++ b/v8.6.0/docs/sdk-ui-charts.igridconfig.enabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.igridconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.igridconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheadlineprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheadlineprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iheatmapprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iheatmapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegendconfig.enabled.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegendconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegendconfig.position.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegendconfig.responsive.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegenddata.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegenddata.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegenddata.legenditems.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegenddata.legenditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegenditem.color.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegenditem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegenditem.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegenditem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegenditem.name.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegenditem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilegenditem.onclick.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilegenditem.onclick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ilinechartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ilinechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ipiechartprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ipiechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.iscatterplotprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.iscatterplotprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itooltipconfig.enabled.html
+++ b/v8.6.0/docs/sdk-ui-charts.itooltipconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itooltipconfig.html
+++ b/v8.6.0/docs/sdk-ui-charts.itooltipconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.itreemapprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.itreemapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
+++ b/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.measure.html
+++ b/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.ixirrprops.html
+++ b/v8.6.0/docs/sdk-ui-charts.ixirrprops.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.linechart.html
+++ b/v8.6.0/docs/sdk-ui-charts.linechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.onlegendready.html
+++ b/v8.6.0/docs/sdk-ui-charts.onlegendready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.piechart.html
+++ b/v8.6.0/docs/sdk-ui-charts.piechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.positiontype.html
+++ b/v8.6.0/docs/sdk-ui-charts.positiontype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.scatterplot.html
+++ b/v8.6.0/docs/sdk-ui-charts.scatterplot.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.treemap.html
+++ b/v8.6.0/docs/sdk-ui-charts.treemap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.viewbyattributeslimit.html
+++ b/v8.6.0/docs/sdk-ui-charts.viewbyattributeslimit.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-charts.xirr.html
+++ b/v8.6.0/docs/sdk-ui-charts.xirr.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.absolutedatefilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.absolutedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.attributeelements.html
+++ b/v8.6.0/docs/sdk-ui-filters.attributeelements.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.attributefilter.html
+++ b/v8.6.0/docs/sdk-ui-filters.attributefilter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.attributefilterbutton.html
+++ b/v8.6.0/docs/sdk-ui-filters.attributefilterbutton.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.attributelistitem.html
+++ b/v8.6.0/docs/sdk-ui-filters.attributelistitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilter._constructor_.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilter._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilter.componentdidmount.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilter.componentdidmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilter.defaultprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilter.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilter.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilter.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilter.render.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilter.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilterhelpers.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilterhelpers.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
+++ b/v8.6.0/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.defaultdatefilteroptions.html
+++ b/v8.6.0/docs/sdk-ui-filters.defaultdatefilteroptions.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.emptylistitem.empty.html
+++ b/v8.6.0/docs/sdk-ui-filters.emptylistitem.empty.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.emptylistitem.html
+++ b/v8.6.0/docs/sdk-ui-filters.emptylistitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
+++ b/v8.6.0/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.granularityintlkey.html
+++ b/v8.6.0/docs/sdk-ui-filters.granularityintlkey.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.html
+++ b/v8.6.0/docs/sdk-ui-filters.html
@@ -168,7 +168,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.attributefilterref.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.attributefilterref.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.deletefilter.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.deletefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.iselementsloading.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.iselementsloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.isloaded.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.isloaded.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.ismobile.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.ismobile.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.listitemclass.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.listitemclass.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.maxselectionsize.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.maxselectionsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.onconfigurationchange.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.onconfigurationchange.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showconfigurationbutton.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showconfigurationbutton.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showdeletebutton.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showdeletebutton.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.width.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.applydisabled.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.applydisabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.error.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.error.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isfullwidth.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isfullwidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isinverted.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isinverted.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isloading.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.items.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onapplybuttonclicked.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onapplybuttonclicked.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onclosebuttonclicked.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onclosebuttonclicked.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onrangechange.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onrangechange.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onsearch.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onsearch.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onselect.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onselect.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.parentfiltertitles.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.parentfiltertitles.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.searchstring.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.searchstring.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.selecteditems.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.selecteditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.showitemsfilteredmessage.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.showitemsfilteredmessage.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.totalcount.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownbodyprops.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.ref.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.title.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.type.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownitem.type.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.isloading.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseout.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseout.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseover.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseover.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.ononly.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.ononly.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onselect.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onselect.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.selected.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.selected.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.source.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.source.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.error.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.error.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.children.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.children.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.limit.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.offset.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.options.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.renderbody.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.renderbody.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterbuttonprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.filter.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.identifier.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.locale.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.onapply.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.onerror.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.title.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-filters.iattributefilterprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.icustomgranularityselection.enable.html
+++ b/v8.6.0/docs/sdk-ui-filters.icustomgranularityselection.enable.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.icustomgranularityselection.html
+++ b/v8.6.0/docs/sdk-ui-filters.icustomgranularityselection.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
+++ b/v8.6.0/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idateandmessagetranslator.html
+++ b/v8.6.0/docs/sdk-ui-filters.idateandmessagetranslator.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.locale.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterownprops.locale.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterprops.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstate.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstate.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatetranslator.formatdate.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatetranslator.formatdate.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.idatetranslator.html
+++ b/v8.6.0/docs/sdk-ui-filters.idatetranslator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
+++ b/v8.6.0/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iextendeddatefiltererrors.html
+++ b/v8.6.0/docs/sdk-ui-filters.iextendeddatefiltererrors.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
+++ b/v8.6.0/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.title.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasuredropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterstate.html
+++ b/v8.6.0/docs/sdk-ui-filters.imeasurevaluefilterstate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imessagetranslator.formatmessage.html
+++ b/v8.6.0/docs/sdk-ui-filters.imessagetranslator.formatmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.imessagetranslator.html
+++ b/v8.6.0/docs/sdk-ui-filters.imessagetranslator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.filter.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.locale.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.onapply.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
+++ b/v8.6.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.isabsolutedatefilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.isabsolutedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.isemptylistitem.html
+++ b/v8.6.0/docs/sdk-ui-filters.isemptylistitem.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.isnonemptylistitem.html
+++ b/v8.6.0/docs/sdk-ui-filters.isnonemptylistitem.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.isrelativedatefilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.isrelativedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.isuirelativedatefilterform.html
+++ b/v8.6.0/docs/sdk-ui-filters.isuirelativedatefilterform.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
+++ b/v8.6.0/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.iwarningmessage.html
+++ b/v8.6.0/docs/sdk-ui-filters.iwarningmessage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.render.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.state.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilter.state.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilterdropdown.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilterdropdown.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
+++ b/v8.6.0/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.rankingfilter.html
+++ b/v8.6.0/docs/sdk-ui-filters.rankingfilter.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.rankingfilterdropdown.html
+++ b/v8.6.0/docs/sdk-ui-filters.rankingfilterdropdown.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.relativedatefilteroption.html
+++ b/v8.6.0/docs/sdk-ui-filters.relativedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-filters.warningmessage.html
+++ b/v8.6.0/docs/sdk-ui-filters.warningmessage.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.centerpositionchangedcallback.html
+++ b/v8.6.0/docs/sdk-ui-geo.centerpositionchangedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.geopushpinchart.html
+++ b/v8.6.0/docs/sdk-ui-geo.geopushpinchart.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.html
+++ b/v8.6.0/docs/sdk-ui-geo.html
@@ -115,7 +115,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoattributeitem.data.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoattributeitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoattributeitem.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoattributeitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.center.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.center.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.colormapping.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.colormapping.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.colorpalette.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.colorpalette.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.colors.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.colors.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.isexportmode.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.isexportmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.legend.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.legend.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.limit.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.points.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.separators.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.separators.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.showlabels.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.showlabels.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.viewport.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.viewport.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfig.zoom.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfig.zoom.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfigviewport.area.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfigviewport.area.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfigviewport.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfigviewport.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeoconfigviewportarea.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeoconfigviewportarea.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodata.color.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodata.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodata.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodata.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodata.location.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodata.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodata.segment.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodata.segment.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodata.size.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodata.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodata.tooltiptext.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodata.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodataitem.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodataitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodataitem.index.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodataitem.index.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeodataitem.name.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeodataitem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.enabled.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.position.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.responsive.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolnglat.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolnglat.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolnglat.lat.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolnglat.lat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolnglat.lng.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolnglat.lng.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolocationitem.data.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolocationitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeolocationitem.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeolocationitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeomeasureitem.data.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeomeasureitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeomeasureitem.format.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeomeasureitem.format.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeomeasureitem.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeomeasureitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.minsize.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopointsconfig.minsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.color.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.config.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.config.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.execconfig.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.location.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.size.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeosegmentitem.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeosegmentitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.igeosegmentitem.uris.html
+++ b/v8.6.0/docs/sdk-ui-geo.igeosegmentitem.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.pushpinsizeoption.html
+++ b/v8.6.0/docs/sdk-ui-geo.pushpinsizeoption.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-geo.zoomchangedcallback.html
+++ b/v8.6.0/docs/sdk-ui-geo.zoomchangedcallback.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.columnlocator.html
+++ b/v8.6.0/docs/sdk-ui-pivot.columnlocator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.columnresizedcallback.html
+++ b/v8.6.0/docs/sdk-ui-pivot.columnresizedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.columnwidth.html
+++ b/v8.6.0/docs/sdk-ui-pivot.columnwidth.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.columnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.columnwidthitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.defaultcolumnwidth.html
+++ b/v8.6.0/docs/sdk-ui-pivot.defaultcolumnwidth.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.html
+++ b/v8.6.0/docs/sdk-ui-pivot.html
@@ -139,7 +139,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iattributecolumnlocator.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iattributecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iautocolumnwidth.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iautocolumnwidth.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iautocolumnwidth.value.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iautocolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
+++ b/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
+++ b/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
+++ b/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.html
+++ b/v8.6.0/docs/sdk-ui-pivot.icolumnsizing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnlocator.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imenu.aggregations.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imenu.aggregations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imenu.aggregationtypes.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imenu.aggregationtypes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.imenu.html
+++ b/v8.6.0/docs/sdk-ui-pivot.imenu.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.execconfig.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.menu.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.menu.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.separators.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableprops.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ipivottableprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ipivottableprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
+++ b/v8.6.0/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.isattributecolumnlocator.html
+++ b/v8.6.0/docs/sdk-ui-pivot.isattributecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.6.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.newattributecolumnlocator.html
+++ b/v8.6.0/docs/sdk-ui-pivot.newattributecolumnlocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
+++ b/v8.6.0/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
+++ b/v8.6.0/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.newwidthforattributecolumn.html
+++ b/v8.6.0/docs/sdk-ui-pivot.newwidthforattributecolumn.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
+++ b/v8.6.0/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.pivottable.html
+++ b/v8.6.0/docs/sdk-ui-pivot.pivottable.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
+++ b/v8.6.0/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.html
@@ -114,7 +114,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.themecontextprovider.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.themecontextprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.thememodifier.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.thememodifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.themeprovider.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.themeprovider.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.usetheme.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.usetheme.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.usethemeisloading.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.usethemeisloading.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-theme-provider.withtheme.html
+++ b/v8.6.0/docs/sdk-ui-theme-provider.withtheme.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
+++ b/v8.6.0/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-vis-commons.html
+++ b/v8.6.0/docs/sdk-ui-vis-commons.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-vis-commons.icolormapping.color.html
+++ b/v8.6.0/docs/sdk-ui-vis-commons.icolormapping.color.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-vis-commons.icolormapping.html
+++ b/v8.6.0/docs/sdk-ui-vis-commons.icolormapping.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui-vis-commons.icolormapping.predicate.html
+++ b/v8.6.0/docs/sdk-ui-vis-commons.icolormapping.predicate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.anyarrayof.html
+++ b/v8.6.0/docs/sdk-ui.anyarrayof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.anymeasure.html
+++ b/v8.6.0/docs/sdk-ui.anymeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.anyplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.anyplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.anyplaceholderof.html
+++ b/v8.6.0/docs/sdk-ui.anyplaceholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.arrayof.html
+++ b/v8.6.0/docs/sdk-ui.arrayof.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributefilterorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.attributefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributefiltersorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.attributefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributeitemnamematch.html
+++ b/v8.6.0/docs/sdk-ui.attributeitemnamematch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributemeasureorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.attributemeasureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributeorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.attributeorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributesmeasuresorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.attributesmeasuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.attributesorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.attributesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.backendprovider.html
+++ b/v8.6.0/docs/sdk-ui.backendprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.badrequestsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.badrequestsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.badrequestsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.badrequestsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cancelledsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.cancelledsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cancelledsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.cancelledsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.attribute.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.attribute.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.attributedisplayform.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.attributedisplayform.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.attributes.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.attributes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.attributetags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.attributetags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedataset.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedataset.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetattribute.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetattribute.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedatasets.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.datedatasettags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.datedatasettags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.html
@@ -122,7 +122,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.measure.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.measure.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.measures.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.measuretags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.measuretags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.visualization.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.visualization.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.visualizations.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.cataloghelper.visualizationtags.html
+++ b/v8.6.0/docs/sdk-ui.cataloghelper.visualizationtags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.chartelementtype.html
+++ b/v8.6.0/docs/sdk-ui.chartelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.charttype.html
+++ b/v8.6.0/docs/sdk-ui.charttype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.composedfromidentifier.html
+++ b/v8.6.0/docs/sdk-ui.composedfromidentifier.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.composedfromuri.html
+++ b/v8.6.0/docs/sdk-ui.composedfromuri.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.composedplaceholderresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui.composedplaceholderresolutioncontext.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.converterror.html
+++ b/v8.6.0/docs/sdk-ui.converterror.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.createnumberjsformatter.html
+++ b/v8.6.0/docs/sdk-ui.createnumberjsformatter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataaccessconfig.html
+++ b/v8.6.0/docs/sdk-ui.dataaccessconfig.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datapoint.html
+++ b/v8.6.0/docs/sdk-ui.datapoint.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datapointcoordinates.html
+++ b/v8.6.0/docs/sdk-ui.datapointcoordinates.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataseriesdescriptor.html
+++ b/v8.6.0/docs/sdk-ui.dataseriesdescriptor.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataseriesdescriptormethods.html
+++ b/v8.6.0/docs/sdk-ui.dataseriesdescriptormethods.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataseriesheaders.html
+++ b/v8.6.0/docs/sdk-ui.dataseriesheaders.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataseriesid.html
+++ b/v8.6.0/docs/sdk-ui.dataseriesid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataslicedescriptor.html
+++ b/v8.6.0/docs/sdk-ui.dataslicedescriptor.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataslicedescriptormethods.html
+++ b/v8.6.0/docs/sdk-ui.dataslicedescriptormethods.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datasliceheaders.html
+++ b/v8.6.0/docs/sdk-ui.datasliceheaders.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datasliceid.html
+++ b/v8.6.0/docs/sdk-ui.datasliceid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datatoolargetocomputesdkerror.html
+++ b/v8.6.0/docs/sdk-ui.datatoolargetocomputesdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.datatoolargetodisplaysdkerror.html
+++ b/v8.6.0/docs/sdk-ui.datatoolargetodisplaysdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.data.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.data.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.dataview.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.definition.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.definition.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.fingerprint.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.fingerprint.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.for.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.for.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.forresult.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.forresult.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.html
@@ -111,7 +111,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.result.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.result.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewfacade.warnings.html
+++ b/v8.6.0/docs/sdk-ui.dataviewfacade.warnings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.dataviewwindow.html
+++ b/v8.6.0/docs/sdk-ui.dataviewwindow.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.defaultcolorpalette.html
+++ b/v8.6.0/docs/sdk-ui.defaultcolorpalette.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.defaultdataaccessconfig.html
+++ b/v8.6.0/docs/sdk-ui.defaultdataaccessconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.defaulterrorhandler.html
+++ b/v8.6.0/docs/sdk-ui.defaulterrorhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.defaultlocale.html
+++ b/v8.6.0/docs/sdk-ui.defaultlocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.drilleventintersectionelementheader.html
+++ b/v8.6.0/docs/sdk-ui.drilleventintersectionelementheader.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.errorcodes.html
+++ b/v8.6.0/docs/sdk-ui.errorcodes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.errorcomponent.defaultprops.html
+++ b/v8.6.0/docs/sdk-ui.errorcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.errorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.errorcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.errorcomponent.render.html
+++ b/v8.6.0/docs/sdk-ui.errorcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.execute.html
+++ b/v8.6.0/docs/sdk-ui.execute.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.executeinsight.html
+++ b/v8.6.0/docs/sdk-ui.executeinsight.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.explicitdrill.html
+++ b/v8.6.0/docs/sdk-ui.explicitdrill.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.filterormultivalueplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.filterormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.filterorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.filterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.filtersorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.filtersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.flatten.html
+++ b/v8.6.0/docs/sdk-ui.flatten.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.geolocationmissingsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.geolocationmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.geotokenmissingsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.geotokenmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror.cause.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror.getcause.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror.getcause.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror.getmessage.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror.getmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror.html
@@ -106,7 +106,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.gooddatasdkerror.setype.html
+++ b/v8.6.0/docs/sdk-ui.gooddatasdkerror.setype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.headerpredicates.html
+++ b/v8.6.0/docs/sdk-ui.headerpredicates.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.headertranslator.html
+++ b/v8.6.0/docs/sdk-ui.headertranslator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.headlineelementtype.html
+++ b/v8.6.0/docs/sdk-ui.headlineelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.headlinetype.html
+++ b/v8.6.0/docs/sdk-ui.headlinetype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.html
+++ b/v8.6.0/docs/sdk-ui.html
@@ -333,7 +333,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iattritem.defaultdisplayform.html
+++ b/v8.6.0/docs/sdk-ui.iattritem.defaultdisplayform.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iattritem.displayforms.html
+++ b/v8.6.0/docs/sdk-ui.iattritem.displayforms.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iattritem.html
+++ b/v8.6.0/docs/sdk-ui.iattritem.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iattritem.identifier.html
+++ b/v8.6.0/docs/sdk-ui.iattritem.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iattritem.tags.html
+++ b/v8.6.0/docs/sdk-ui.iattritem.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iattrs.html
+++ b/v8.6.0/docs/sdk-ui.iattrs.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ibackendproviderprops.backend.html
+++ b/v8.6.0/docs/sdk-ui.ibackendproviderprops.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ibackendproviderprops.html
+++ b/v8.6.0/docs/sdk-ui.ibackendproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icatalog.attributes.html
+++ b/v8.6.0/docs/sdk-ui.icatalog.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icatalog.datedatasets.html
+++ b/v8.6.0/docs/sdk-ui.icatalog.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icatalog.html
+++ b/v8.6.0/docs/sdk-ui.icatalog.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icatalog.measures.html
+++ b/v8.6.0/docs/sdk-ui.icatalog.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icatalog.visualizations.html
+++ b/v8.6.0/docs/sdk-ui.icatalog.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icomposedplaceholder.computevalue.html
+++ b/v8.6.0/docs/sdk-ui.icomposedplaceholder.computevalue.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icomposedplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.icomposedplaceholder.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icomposedplaceholder.placeholders.html
+++ b/v8.6.0/docs/sdk-ui.icomposedplaceholder.placeholders.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icomposedplaceholder.type.html
+++ b/v8.6.0/docs/sdk-ui.icomposedplaceholder.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.icomposedplaceholder.use.html
+++ b/v8.6.0/docs/sdk-ui.icomposedplaceholder.use.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataaccessmethods.html
+++ b/v8.6.0/docs/sdk-ui.idataaccessmethods.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataaccessmethods.series.html
+++ b/v8.6.0/docs/sdk-ui.idataaccessmethods.series.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataaccessmethods.slices.html
+++ b/v8.6.0/docs/sdk-ui.idataaccessmethods.slices.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseries.datapoints.html
+++ b/v8.6.0/docs/sdk-ui.idataseries.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseries.descriptor.html
+++ b/v8.6.0/docs/sdk-ui.idataseries.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseries.html
+++ b/v8.6.0/docs/sdk-ui.idataseries.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseries.id.html
+++ b/v8.6.0/docs/sdk-ui.idataseries.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseries.rawdata.html
+++ b/v8.6.0/docs/sdk-ui.idataseries.rawdata.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.allformeasure.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.allformeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.count.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.firstformeasure.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.firstformeasure.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.frommeasures.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.frommeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.html
@@ -100,7 +100,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.scopingattributes.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.scopingattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataseriescollection.toarray.html
+++ b/v8.6.0/docs/sdk-ui.idataseriescollection.toarray.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataset.attributes.html
+++ b/v8.6.0/docs/sdk-ui.idataset.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataset.html
+++ b/v8.6.0/docs/sdk-ui.idataset.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataset.identifier.html
+++ b/v8.6.0/docs/sdk-ui.idataset.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataset.tags.html
+++ b/v8.6.0/docs/sdk-ui.idataset.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslice.datapoints.html
+++ b/v8.6.0/docs/sdk-ui.idataslice.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslice.descriptor.html
+++ b/v8.6.0/docs/sdk-ui.idataslice.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslice.html
+++ b/v8.6.0/docs/sdk-ui.idataslice.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslice.id.html
+++ b/v8.6.0/docs/sdk-ui.idataslice.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslice.rawdata.html
+++ b/v8.6.0/docs/sdk-ui.idataslice.rawdata.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslicecollection.count.html
+++ b/v8.6.0/docs/sdk-ui.idataslicecollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslicecollection.descriptors.html
+++ b/v8.6.0/docs/sdk-ui.idataslicecollection.descriptors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslicecollection.html
+++ b/v8.6.0/docs/sdk-ui.idataslicecollection.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idataslicecollection.toarray.html
+++ b/v8.6.0/docs/sdk-ui.idataslicecollection.toarray.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idatavisualizationprops.execution.html
+++ b/v8.6.0/docs/sdk-ui.idatavisualizationprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idatavisualizationprops.html
+++ b/v8.6.0/docs/sdk-ui.idatavisualizationprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.identifiermatch.html
+++ b/v8.6.0/docs/sdk-ui.identifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idisplayforms.html
+++ b/v8.6.0/docs/sdk-ui.idisplayforms.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillableitem.html
+++ b/v8.6.0/docs/sdk-ui.idrillableitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillableitemidentifier.html
+++ b/v8.6.0/docs/sdk-ui.idrillableitemidentifier.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillableitemidentifier.identifier.html
+++ b/v8.6.0/docs/sdk-ui.idrillableitemidentifier.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillableitemuri.html
+++ b/v8.6.0/docs/sdk-ui.idrillableitemuri.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillableitemuri.uri.html
+++ b/v8.6.0/docs/sdk-ui.idrillableitemuri.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillconfig.dataview.html
+++ b/v8.6.0/docs/sdk-ui.idrillconfig.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillconfig.html
+++ b/v8.6.0/docs/sdk-ui.idrillconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillconfig.ondrill.html
+++ b/v8.6.0/docs/sdk-ui.idrillconfig.ondrill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillevent.dataview.html
+++ b/v8.6.0/docs/sdk-ui.idrillevent.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillevent.drillcontext.html
+++ b/v8.6.0/docs/sdk-ui.idrillevent.drillcontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillevent.html
+++ b/v8.6.0/docs/sdk-ui.idrillevent.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcallback.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.columnindex.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.element.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.intersection.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.points.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.row.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.rowindex.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.type.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.value.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.x.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.y.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontext.z.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontext.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.element.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.points.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.type.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextgroup.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.element.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.intersection.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.type.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.value.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextheadline.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.element.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.intersection.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.type.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.value.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.x.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.y.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.z.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextpoint.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.columnindex.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.element.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.intersection.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.row.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.rowindex.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontexttable.type.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontexttable.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.element.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.intersection.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.type.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.value.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventcontextxirr.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventintersectionelement.header.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventintersectionelement.header.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrilleventintersectionelement.html
+++ b/v8.6.0/docs/sdk-ui.idrilleventintersectionelement.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillintersectionattributeitem.html
+++ b/v8.6.0/docs/sdk-ui.idrillintersectionattributeitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillpoint.html
+++ b/v8.6.0/docs/sdk-ui.idrillpoint.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillpoint.intersection.html
+++ b/v8.6.0/docs/sdk-ui.idrillpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillpoint.type.html
+++ b/v8.6.0/docs/sdk-ui.idrillpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillpoint.x.html
+++ b/v8.6.0/docs/sdk-ui.idrillpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.idrillpoint.y.html
+++ b/v8.6.0/docs/sdk-ui.idrillpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrordescriptors.html
+++ b/v8.6.0/docs/sdk-ui.ierrordescriptors.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.classname.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.clientheight.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.clientheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.code.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.code.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.description.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.height.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.icon.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.icon.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.message.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.message.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.style.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.style.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ierrorprops.width.html
+++ b/v8.6.0/docs/sdk-ui.ierrorprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteerrorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteerrorcomponent.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteerrorcomponentprops.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteerrorcomponentprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.backend.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.children.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.children.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.componentname.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.dateformat.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.dimensions.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.filters.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.insight.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.insight.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.sorts.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.window.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.window.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteinsightprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteinsightprops.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteloadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteloadingcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.backend.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.children.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.componentname.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.componentname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.errorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.errorcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.exporttitle.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.filters.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.loadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.loadonmount.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.seriesby.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.seriesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.slicesby.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.slicesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.sortby.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.totals.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.window.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecuteprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui.iexecuteprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.componentname.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.filters.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.seriesby.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.slicesby.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.sortby.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexecutionconfiguration.totals.html
+++ b/v8.6.0/docs/sdk-ui.iexecutionconfiguration.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iexportfunction.html
+++ b/v8.6.0/docs/sdk-ui.iexportfunction.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iextendedexportconfig.html
+++ b/v8.6.0/docs/sdk-ui.iextendedexportconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
+++ b/v8.6.0/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iheaderpredicate.html
+++ b/v8.6.0/docs/sdk-ui.iheaderpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iheaderpredicatecontext.dv.html
+++ b/v8.6.0/docs/sdk-ui.iheaderpredicatecontext.dv.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iheaderpredicatecontext.html
+++ b/v8.6.0/docs/sdk-ui.iheaderpredicatecontext.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ihighchartscategoriestree.html
+++ b/v8.6.0/docs/sdk-ui.ihighchartscategoriestree.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ihighchartscategoriestree.tick.html
+++ b/v8.6.0/docs/sdk-ui.ihighchartscategoriestree.tick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ihighchartsparenttick.html
+++ b/v8.6.0/docs/sdk-ui.ihighchartsparenttick.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ihighchartsparenttick.label.html
+++ b/v8.6.0/docs/sdk-ui.ihighchartsparenttick.label.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ihighchartsparenttick.leaves.html
+++ b/v8.6.0/docs/sdk-ui.ihighchartsparenttick.leaves.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ihighchartsparenttick.startat.html
+++ b/v8.6.0/docs/sdk-ui.ihighchartsparenttick.startat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iidentifierwithtags.html
+++ b/v8.6.0/docs/sdk-ui.iidentifierwithtags.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iidentifierwithtags.identifier.html
+++ b/v8.6.0/docs/sdk-ui.iidentifierwithtags.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iidentifierwithtags.tags.html
+++ b/v8.6.0/docs/sdk-ui.iidentifierwithtags.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.backend.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.errorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.filters.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.loadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.locale.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.measure.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.separators.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ikpiprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui.ikpiprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.classname.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.color.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.height.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.height.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.imageheight.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.imageheight.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.imagewidth.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.imagewidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.inline.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.inline.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.speed.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.speed.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingprops.width.html
+++ b/v8.6.0/docs/sdk-ui.iloadingprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingstate.html
+++ b/v8.6.0/docs/sdk-ui.iloadingstate.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iloadingstate.isloading.html
+++ b/v8.6.0/docs/sdk-ui.iloadingstate.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ilocale.html
+++ b/v8.6.0/docs/sdk-ui.ilocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.imappingheader.html
+++ b/v8.6.0/docs/sdk-ui.imappingheader.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholderoptions.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholderoptions.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholderoptions.id.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholderoptions.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholderoptions.validate.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholderoptions.validate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholdersproviderprops.children.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholdersproviderprops.children.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholdersproviderprops.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholdersproviderprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
+++ b/v8.6.0/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.children.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.errorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.execution.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.exporttitle.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.loadonmount.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.irawexecuteprops.window.html
+++ b/v8.6.0/docs/sdk-ui.irawexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isanyplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.isanyplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isbadrequest.html
+++ b/v8.6.0/docs/sdk-ui.isbadrequest.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iscancelledsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.iscancelledsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iscomposedplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.iscomposedplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isdatatoolargetocompute.html
+++ b/v8.6.0/docs/sdk-ui.isdatatoolargetocompute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isdatatoolargetodisplay.html
+++ b/v8.6.0/docs/sdk-ui.isdatatoolargetodisplay.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isdrillableitem.html
+++ b/v8.6.0/docs/sdk-ui.isdrillableitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isdrillableitemidentifier.html
+++ b/v8.6.0/docs/sdk-ui.isdrillableitemidentifier.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isdrillableitemuri.html
+++ b/v8.6.0/docs/sdk-ui.isdrillableitemuri.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isdrillintersectionattributeitem.html
+++ b/v8.6.0/docs/sdk-ui.isdrillintersectionattributeitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isexplicitdrill.html
+++ b/v8.6.0/docs/sdk-ui.isexplicitdrill.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isgeolocationmissing.html
+++ b/v8.6.0/docs/sdk-ui.isgeolocationmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isgeotokenmissing.html
+++ b/v8.6.0/docs/sdk-ui.isgeotokenmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isgooddatasdkerror.html
+++ b/v8.6.0/docs/sdk-ui.isgooddatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isheaderpredicate.html
+++ b/v8.6.0/docs/sdk-ui.isheaderpredicate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isnegativevalues.html
+++ b/v8.6.0/docs/sdk-ui.isnegativevalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isnodatasdkerror.html
+++ b/v8.6.0/docs/sdk-ui.isnodatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isnotfound.html
+++ b/v8.6.0/docs/sdk-ui.isnotfound.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.isplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isprotectedreport.html
+++ b/v8.6.0/docs/sdk-ui.isprotectedreport.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isunauthorized.html
+++ b/v8.6.0/docs/sdk-ui.isunauthorized.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.isunknownsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.isunknownsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iusecomposedplaceholderhook.html
+++ b/v8.6.0/docs/sdk-ui.iusecomposedplaceholderhook.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.backend.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.componentname.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.filters.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.seriesby.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.slicesby.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.sortby.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.totals.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutionconfig.workspace.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutionconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
+++ b/v8.6.0/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.window.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
+++ b/v8.6.0/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iusepagedresourceresult.html
+++ b/v8.6.0/docs/sdk-ui.iusepagedresourceresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iusepagedresourceresult.isloading.html
+++ b/v8.6.0/docs/sdk-ui.iusepagedresourceresult.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iusepagedresourcestate.html
+++ b/v8.6.0/docs/sdk-ui.iusepagedresourcestate.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iusepagedresourcestate.items.html
+++ b/v8.6.0/docs/sdk-ui.iusepagedresourcestate.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
+++ b/v8.6.0/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iuseplaceholderhook.html
+++ b/v8.6.0/docs/sdk-ui.iuseplaceholderhook.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.onerror.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationprops.drillableitems.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationprops.drillableitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationprops.errorcomponent.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationprops.exporttitle.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationprops.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.ivisualizationprops.locale.html
+++ b/v8.6.0/docs/sdk-ui.ivisualizationprops.locale.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iwithloadingevents.html
+++ b/v8.6.0/docs/sdk-ui.iwithloadingevents.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iwithloadingevents.onerror.html
+++ b/v8.6.0/docs/sdk-ui.iwithloadingevents.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iwithloadingevents.onexportready.html
+++ b/v8.6.0/docs/sdk-ui.iwithloadingevents.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
+++ b/v8.6.0/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
+++ b/v8.6.0/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iwithloadingevents.onloadingstart.html
+++ b/v8.6.0/docs/sdk-ui.iwithloadingevents.onloadingstart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iworkspaceproviderprops.html
+++ b/v8.6.0/docs/sdk-ui.iworkspaceproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.iworkspaceproviderprops.workspace.html
+++ b/v8.6.0/docs/sdk-ui.iworkspaceproviderprops.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.kpi.html
+++ b/v8.6.0/docs/sdk-ui.kpi.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.loadingcomponent.defaultprops.html
+++ b/v8.6.0/docs/sdk-ui.loadingcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.loadingcomponent.html
+++ b/v8.6.0/docs/sdk-ui.loadingcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.loadingcomponent.render.html
+++ b/v8.6.0/docs/sdk-ui.loadingcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.localidentifiermatch.html
+++ b/v8.6.0/docs/sdk-ui.localidentifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.measureof.html
+++ b/v8.6.0/docs/sdk-ui.measureof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.measureorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.measureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.measuresorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.measuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.negativevaluessdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.negativevaluessdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.negativevaluessdkerror.html
+++ b/v8.6.0/docs/sdk-ui.negativevaluessdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.newcomposedplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.newcomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.newerrormapping.html
+++ b/v8.6.0/docs/sdk-ui.newerrormapping.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.newplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.newplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.nodatasdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.nodatasdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.nodatasdkerror.html
+++ b/v8.6.0/docs/sdk-ui.nodatasdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.notfoundsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.notfoundsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.notfoundsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.notfoundsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.nullablefilterorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.nullablefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.nullablefiltersorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.nullablefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.onerror.html
+++ b/v8.6.0/docs/sdk-ui.onerror.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.onexportready.html
+++ b/v8.6.0/docs/sdk-ui.onexportready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.onfireddrillevent.html
+++ b/v8.6.0/docs/sdk-ui.onfireddrillevent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.onloadingchanged.html
+++ b/v8.6.0/docs/sdk-ui.onloadingchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.placeholderof.html
+++ b/v8.6.0/docs/sdk-ui.placeholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.placeholderresolvedvalue.html
+++ b/v8.6.0/docs/sdk-ui.placeholderresolvedvalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.placeholdersprovider.html
+++ b/v8.6.0/docs/sdk-ui.placeholdersprovider.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.placeholdersresolvedvalues.html
+++ b/v8.6.0/docs/sdk-ui.placeholdersresolvedvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.placeholdersvalues.html
+++ b/v8.6.0/docs/sdk-ui.placeholdersvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.placeholdervalue.html
+++ b/v8.6.0/docs/sdk-ui.placeholdervalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.protectedreportsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.protectedreportsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.protectedreportsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.protectedreportsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.rawexecute.html
+++ b/v8.6.0/docs/sdk-ui.rawexecute.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.resolveusecancelablepromiseserror.html
+++ b/v8.6.0/docs/sdk-ui.resolveusecancelablepromiseserror.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.resolveusecancelablepromisesstatus.html
+++ b/v8.6.0/docs/sdk-ui.resolveusecancelablepromisesstatus.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.sdkerrortype.html
+++ b/v8.6.0/docs/sdk-ui.sdkerrortype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.sortsorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.sortsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.tableelementtype.html
+++ b/v8.6.0/docs/sdk-ui.tableelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.tabletype.html
+++ b/v8.6.0/docs/sdk-ui.tabletype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.totalsorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.totalsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
+++ b/v8.6.0/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.unauthorizedsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.unauthorizedsdkerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.unexpectedsdkerror._constructor_.html
+++ b/v8.6.0/docs/sdk-ui.unexpectedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.unexpectedsdkerror.html
+++ b/v8.6.0/docs/sdk-ui.unexpectedsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.uniontointersection.html
+++ b/v8.6.0/docs/sdk-ui.uniontointersection.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.urimatch.html
+++ b/v8.6.0/docs/sdk-ui.urimatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usebackend.html
+++ b/v8.6.0/docs/sdk-ui.usebackend.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usebackendstrict.html
+++ b/v8.6.0/docs/sdk-ui.usebackendstrict.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromise.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromise.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromisecallbacks.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromisecallbacks.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromiseerrorstate.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromiseerrorstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromiseloadingstate.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromiseloadingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromisependingstate.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromisependingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromisestate.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromisestate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromisestatus.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromisestatus.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecancelablepromisesuccessstate.html
+++ b/v8.6.0/docs/sdk-ui.usecancelablepromisesuccessstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usecomposedplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.usecomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usedataexport.html
+++ b/v8.6.0/docs/sdk-ui.usedataexport.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usedataexportcallbacks.html
+++ b/v8.6.0/docs/sdk-ui.usedataexportcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usedataexportstate.html
+++ b/v8.6.0/docs/sdk-ui.usedataexportstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usedataview.html
+++ b/v8.6.0/docs/sdk-ui.usedataview.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usedataviewcallbacks.html
+++ b/v8.6.0/docs/sdk-ui.usedataviewcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usedataviewstate.html
+++ b/v8.6.0/docs/sdk-ui.usedataviewstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useexecution.html
+++ b/v8.6.0/docs/sdk-ui.useexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useexecutiondataview.html
+++ b/v8.6.0/docs/sdk-ui.useexecutiondataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useinsightdataview.html
+++ b/v8.6.0/docs/sdk-ui.useinsightdataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.usepagedresource.html
+++ b/v8.6.0/docs/sdk-ui.usepagedresource.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.useplaceholder.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.useplaceholders.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useresolvevalueswithplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.useresolvevalueswithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useresolvevaluewithplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.useresolvevaluewithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useworkspace.html
+++ b/v8.6.0/docs/sdk-ui.useworkspace.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.useworkspacestrict.html
+++ b/v8.6.0/docs/sdk-ui.useworkspacestrict.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.valueformatter.html
+++ b/v8.6.0/docs/sdk-ui.valueformatter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.valueormultivalueplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.valueormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.valueorplaceholder.html
+++ b/v8.6.0/docs/sdk-ui.valueorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.valuesorplaceholders.html
+++ b/v8.6.0/docs/sdk-ui.valuesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.viselementtype.html
+++ b/v8.6.0/docs/sdk-ui.viselementtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.vistype.html
+++ b/v8.6.0/docs/sdk-ui.vistype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.withloadingresult.html
+++ b/v8.6.0/docs/sdk-ui.withloadingresult.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.workspaceprovider.html
+++ b/v8.6.0/docs/sdk-ui.workspaceprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/docs/sdk-ui.xirrtype.html
+++ b/v8.6.0/docs/sdk-ui.xirrtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/en/help.html
+++ b/v8.6.0/en/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/en/index.html
+++ b/v8.6.0/en/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/en/users.html
+++ b/v8.6.0/en/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/help.html
+++ b/v8.6.0/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/index.html
+++ b/v8.6.0/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.6.0/users.html
+++ b/v8.6.0/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.6.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/index.html
+++ b/v8.7.0/docs/index.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
+++ b/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror.cause.html
+++ b/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror.html
+++ b/v8.7.0/docs/sdk-backend-spi.analyticalbackenderror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.analyticalbackenderrortypes.html
+++ b/v8.7.0/docs/sdk-backend-spi.analyticalbackenderrortypes.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.analyticalbackendfactory.html
+++ b/v8.7.0/docs/sdk-backend-spi.analyticalbackendfactory.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.attributedescriptorlocalid.html
+++ b/v8.7.0/docs/sdk-backend-spi.attributedescriptorlocalid.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.attributedescriptorname.html
+++ b/v8.7.0/docs/sdk-backend-spi.attributedescriptorname.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.authenticationflow.html
+++ b/v8.7.0/docs/sdk-backend-spi.authenticationflow.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.catalogitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.catalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.catalogitemmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.catalogitemmetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.catalogitemtype.html
+++ b/v8.7.0/docs/sdk-backend-spi.catalogitemtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.datacolumntype.html
+++ b/v8.7.0/docs/sdk-backend-spi.datacolumntype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.datasetloadstatus.html
+++ b/v8.7.0/docs/sdk-backend-spi.datasetloadstatus.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.datatoolargeerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.datatoolargeerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.datavalue.html
+++ b/v8.7.0/docs/sdk-backend-spi.datavalue.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.errorconverter.html
+++ b/v8.7.0/docs/sdk-backend-spi.errorconverter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.filterwithresolvableelements.html
+++ b/v8.7.0/docs/sdk-backend-spi.filterwithresolvableelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.groupablecatalogitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.groupablecatalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.html
+++ b/v8.7.0/docs/sdk-backend-spi.html
@@ -289,7 +289,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.config.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.organization.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.organization.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalbackendconfig.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalbackendconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.users.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.users.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelement.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelement.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelement.title.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelement.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelement.uri.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelement.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.drilltoattributelink.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.drilltoattributelink.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.iattributemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticatedprincipal.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticatedprincipal.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationcontext.backend.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationcontext.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationcontext.client.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationcontext.client.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationcontext.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationcontext.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
+++ b/v8.7.0/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.hastypescopedidentifiers.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.hastypescopedidentifiers.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.html
@@ -106,7 +106,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsaccesscontrol.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsaccesscontrol.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsexplain.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsexplain.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.usesstrictaccesscontrol.html
+++ b/v8.7.0/docs/sdk-backend-spi.ibackendcapabilities.usesstrictaccesscontrol.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogattribute.attribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogattribute.displayforms.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogattribute.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogattribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogattribute.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogattribute.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogattribute.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdateattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogdatedataset.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogfact.fact.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogfact.fact.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogfact.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogfact.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogfact.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icataloggroup.html
+++ b/v8.7.0/docs/sdk-backend-spi.icataloggroup.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icataloggroup.tag.html
+++ b/v8.7.0/docs/sdk-backend-spi.icataloggroup.tag.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icataloggroup.title.html
+++ b/v8.7.0/docs/sdk-backend-spi.icataloggroup.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogitembase.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogitembase.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogitembase.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogitembase.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogmeasure.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogmeasure.measure.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogmeasure.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.icatalogmeasure.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.icatalogmeasure.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idashboardmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.idashboardmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idashboardmetadataobject.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.idashboardmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatacolumn.column.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatacolumn.column.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatacolumn.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatacolumn.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataheader.columns.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataheader.columns.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataheader.headerrowindex.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataheader.headerrowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataset.dataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataset.dataset.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataset.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.created.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.created.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.owner.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.owner.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.status.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetloadinfo.status.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetmetadataobject.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetuser.fullname.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetuser.fullname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetuser.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatasetuser.login.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatasetuser.login.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.count.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.data.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.data.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.definition.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.equals.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.fingerprint.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.headeritems.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.headeritems.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.offset.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.result.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.result.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.totalcount.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.totalcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.totals.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.totals.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idataview.warnings.html
+++ b/v8.7.0/docs/sdk-backend-spi.idataview.warnings.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idimensiondescriptor.headers.html
+++ b/v8.7.0/docs/sdk-backend-spi.idimensiondescriptor.headers.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idimensiondescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.idimensiondescriptor.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.idimensionitemdescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.idimensionitemdescriptor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.query.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.withdatefilters.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.withdatefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.withlimit.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.withmeasures.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.withmeasures.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.withoffset.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsquery.withoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryattributefilter.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryattributefilter.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryfactory.forfilter.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryfactory.forfilter.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryfactory.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.order.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.order.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ielementsqueryresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.ielementsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
@@ -36,7 +36,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.foritems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.foritems.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionfactory.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.definition.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.dimensions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.dimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.equals.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.export.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.export.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.readall.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.readall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.readwindow.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.readwindow.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexecutionresult.transform.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexecutionresult.transform.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportconfig.format.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportconfig.format.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportconfig.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportconfig.showfilters.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportconfig.showfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportconfig.title.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportconfig.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iexportresult.uri.html
+++ b/v8.7.0/docs/sdk-backend-spi.iexportresult.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ifactmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.ifactmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ifactmetadataobject.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.ifactmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.html
+++ b/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.query.html
+++ b/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.withlimit.html
+++ b/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.withoffset.html
+++ b/v8.7.0/docs/sdk-backend-spi.ifilterelementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.igetinsightoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.igetinsightoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.igetinsightoptions.loaduserdata.html
+++ b/v8.7.0/docs/sdk-backend-spi.igetinsightoptions.loaduserdata.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
+++ b/v8.7.0/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
+++ b/v8.7.0/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.igroupablecatalogitembase.html
+++ b/v8.7.0/docs/sdk-backend-spi.igroupablecatalogitembase.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightreferences.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightreferences.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightreferencing.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightreferencing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.loaduserdata.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.loaduserdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iinsightsqueryresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.iinsightsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasuredescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasuredescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasureexpressiontoken.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasureexpressiontoken.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasuregroupdescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasuregroupdescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasuremetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasuremetadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasurereferencing.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasurereferencing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasurereferencing.insights.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasurereferencing.insights.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imeasurereferencing.measures.html
+++ b/v8.7.0/docs/sdk-backend-spi.imeasurereferencing.measures.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.imetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.imetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.insightordering.html
+++ b/v8.7.0/docs/sdk-backend-spi.insightordering.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.insightreferencetypes.html
+++ b/v8.7.0/docs/sdk-backend-spi.insightreferencetypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.html
+++ b/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.id.html
+++ b/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
+++ b/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
+++ b/v8.7.0/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganization.getdescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganization.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganization.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganization.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganization.organizationid.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganization.organizationid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganization.securitysettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganization.securitysettings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganizationdescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganizationdescriptor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganizationdescriptor.id.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganizationdescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganizationdescriptor.title.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganizationdescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iorganizations.html
+++ b/v8.7.0/docs/sdk-backend-spi.iorganizations.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.all.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.all.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.allsorted.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.allsorted.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.goto.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.goto.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.items.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.limit.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.next.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.next.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.offset.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.offset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipagedresource.totalcount.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipagedresource.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.definition.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.equals.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.execute.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.execute.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
+++ b/v8.7.0/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultattributeheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultattributeheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultheader.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultmeasureheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultmeasureheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresulttotalheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresulttotalheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultwarning.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultwarning.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultwarning.message.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultwarning.message.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultwarning.parameters.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultwarning.parameters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iresultwarning.warningcode.html
+++ b/v8.7.0/docs/sdk-backend-spi.iresultwarning.warningcode.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isanalyticalbackenderror.html
+++ b/v8.7.0/docs/sdk-backend-spi.isanalyticalbackenderror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isattributedescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.isattributedescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isattributemetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.isattributemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iscatalogattribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.iscatalogattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iscatalogdatedataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.iscatalogdatedataset.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iscatalogfact.html
+++ b/v8.7.0/docs/sdk-backend-spi.iscatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iscatalogmeasure.html
+++ b/v8.7.0/docs/sdk-backend-spi.iscatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isdashboardmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.isdashboardmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isdatasetmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.isdatasetmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isdatatoolargeerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.isdatatoolargeerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.isdashboardpluginurlvalid.html
+++ b/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.isdashboardpluginurlvalid.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
+++ b/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
+++ b/v8.7.0/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iseparators.decimal.html
+++ b/v8.7.0/docs/sdk-backend-spi.iseparators.decimal.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iseparators.html
+++ b/v8.7.0/docs/sdk-backend-spi.iseparators.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iseparators.thousand.html
+++ b/v8.7.0/docs/sdk-backend-spi.iseparators.thousand.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableanalyticaldashboardpermissions.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableanalyticaldashboardpermissions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableapproxcount.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableapproxcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablebulletchart.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablebulletchart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableclickableattributeurl.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableclickableattributeurl.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablecompanylogoinembeddedui.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablecompanylogoinembeddedui.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enabledatasampling.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enabledatasampling.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enabledrilledinsightexport.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enabledrilledinsightexport.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableinsighttoreport.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableinsighttoreport.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekdzooming.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekdzooming.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardimplicitdrilldown.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardimplicitdrilldown.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablemultipledates.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablemultipledates.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enablesectionheaders.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enablesectionheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.enableweekfilters.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.enableweekfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.hidekpidrillinembedded.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.hidekpidrillinembedded.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.html
@@ -118,7 +118,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.platformedition.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.platformedition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
+++ b/v8.7.0/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isfactmetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.isfactmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ismeasuredescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ismeasuredescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ismeasuremetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.ismeasuremetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
+++ b/v8.7.0/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ismetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.ismetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isnodataerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.isnodataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isnotauthenticated.html
+++ b/v8.7.0/docs/sdk-backend-spi.isnotauthenticated.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isnotimplemented.html
+++ b/v8.7.0/docs/sdk-backend-spi.isnotimplemented.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isnotsupported.html
+++ b/v8.7.0/docs/sdk-backend-spi.isnotsupported.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isprotecteddataerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.isprotecteddataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isresultattributeheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.isresultattributeheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isresultmeasureheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.isresultmeasureheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isresulttotalheader.html
+++ b/v8.7.0/docs/sdk-backend-spi.isresulttotalheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.istotaldescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.istotaldescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isunexpectederror.html
+++ b/v8.7.0/docs/sdk-backend-spi.isunexpectederror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isunexpectedresponseerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.isunexpectedresponseerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.isvariablemetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.isvariablemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itextexpressiontoken.html
+++ b/v8.7.0/docs/sdk-backend-spi.itextexpressiontoken.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itextexpressiontoken.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.itextexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itextexpressiontoken.value.html
+++ b/v8.7.0/docs/sdk-backend-spi.itextexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.analyticaldesigner.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.analyticaldesigner.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.button.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.button.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.chart.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.chart.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.dashboards.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.dashboards.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.kpi.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.kpi.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.modal.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.modal.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.palette.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.palette.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.table.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.table.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.tooltip.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.tooltip.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itheme.typography.html
+++ b/v8.7.0/docs/sdk-backend-spi.itheme.typography.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.axiscolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.axiscolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.gridcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.base.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.base.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.dark.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.dark.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.light.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecolorfamily.light.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemecomplementarypalette.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemekpi.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemekpi.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemekpi.value.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemekpi.value.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.complementary.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.complementary.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.error.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.error.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.info.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.info.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.primary.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.primary.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.success.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.success.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemepalette.warning.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemepalette.warning.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.gridcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetable.valuecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetable.valuecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetypography.font.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetypography.font.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetypography.fontbold.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetypography.fontbold.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemetypography.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemetypography.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemewidgettitle.color.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemewidgettitle.color.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemewidgettitle.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemewidgettitle.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
+++ b/v8.7.0/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itotaldescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.itotaldescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
+++ b/v8.7.0/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iuserservice.getuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.iuserservice.getuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iuserservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iuserservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iuserservice.settings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iuserservice.settings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iusersettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iusersettings.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iusersettings.locale.html
+++ b/v8.7.0/docs/sdk-backend-spi.iusersettings.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iusersettings.separators.html
+++ b/v8.7.0/docs/sdk-backend-spi.iusersettings.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iusersettings.userid.html
+++ b/v8.7.0/docs/sdk-backend-spi.iusersettings.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iusersettingsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iusersettingsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iuserworkspacesettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iuserworkspacesettings.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ivariablemetadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.ivariablemetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.ivariablemetadataobject.type.html
+++ b/v8.7.0/docs/sdk-backend-spi.ivariablemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceattributesservice.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalog.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalog.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedatasetsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedatasetsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.description.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.id.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.title.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacedescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacefactsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacefactsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasurereferencingobjects.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasurereferencingobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacepermissions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacepermissions.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacepermissionsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacepermissionsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesettings.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesettings.workspace.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesettings.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesettingsservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesettingsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.query.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.query.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryfactory.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryresult.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryresult.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryresult.search.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacesqueryresult.search.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspacestylingservice.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspacestylingservice.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.email.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.firstname.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.fullname.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.lastname.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.login.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.ref.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.uri.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceuser.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceusersquery.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceusersquery.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
+++ b/v8.7.0/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.metadataobject.html
+++ b/v8.7.0/docs/sdk-backend-spi.metadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.metadataobjectid.html
+++ b/v8.7.0/docs/sdk-backend-spi.metadataobjectid.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.nodataerror._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.nodataerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.nodataerror.dataview.html
+++ b/v8.7.0/docs/sdk-backend-spi.nodataerror.dataview.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.nodataerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.nodataerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notauthenticated._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.notauthenticated._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
+++ b/v8.7.0/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notauthenticated.html
+++ b/v8.7.0/docs/sdk-backend-spi.notauthenticated.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notauthenticatedhandler.html
+++ b/v8.7.0/docs/sdk-backend-spi.notauthenticatedhandler.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notimplemented._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.notimplemented._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notimplemented.html
+++ b/v8.7.0/docs/sdk-backend-spi.notimplemented.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notsupported._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.notsupported._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.notsupported.html
+++ b/v8.7.0/docs/sdk-backend-spi.notsupported.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.platformedition.html
+++ b/v8.7.0/docs/sdk-backend-spi.platformedition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.prepareexecution.html
+++ b/v8.7.0/docs/sdk-backend-spi.prepareexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.protecteddataerror._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.protecteddataerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.protecteddataerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.protecteddataerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.resultheadername.html
+++ b/v8.7.0/docs/sdk-backend-spi.resultheadername.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.supportedinsightreferencetypes.html
+++ b/v8.7.0/docs/sdk-backend-spi.supportedinsightreferencetypes.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.themecolor.html
+++ b/v8.7.0/docs/sdk-backend-spi.themecolor.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.themefonturi.html
+++ b/v8.7.0/docs/sdk-backend-spi.themefonturi.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.unexpectederror._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.unexpectederror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.unexpectederror.html
+++ b/v8.7.0/docs/sdk-backend-spi.unexpectederror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
+++ b/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror.html
+++ b/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
+++ b/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
+++ b/v8.7.0/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.validationcontext.html
+++ b/v8.7.0/docs/sdk-backend-spi.validationcontext.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-backend-spi.workspacepermission.html
+++ b/v8.7.0/docs/sdk-backend-spi.workspacepermission.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.absolutedatefiltervalues.html
+++ b/v8.7.0/docs/sdk-model.absolutedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.alltimegranularity.html
+++ b/v8.7.0/docs/sdk-model.alltimegranularity.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.anyattribute.html
+++ b/v8.7.0/docs/sdk-model.anyattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.anybucket.html
+++ b/v8.7.0/docs/sdk-model.anybucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.anymeasure.html
+++ b/v8.7.0/docs/sdk-model.anymeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.applyratiorule.html
+++ b/v8.7.0/docs/sdk-model.applyratiorule.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.areobjrefsequal.html
+++ b/v8.7.0/docs/sdk-model.areobjrefsequal.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.operands.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.operands.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.operator.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasurebuilder.operator.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasurebuilderinput.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.arithmeticmeasureoperator.html
+++ b/v8.7.0/docs/sdk-model.arithmeticmeasureoperator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributealias.html
+++ b/v8.7.0/docs/sdk-model.attributealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.alias.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.build.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.build.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.defaultlocalid.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.displayform.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.localid.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilder.noalias.html
+++ b/v8.7.0/docs/sdk-model.attributebuilder.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributebuilderinput.html
+++ b/v8.7.0/docs/sdk-model.attributebuilderinput.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributedisplayformref.html
+++ b/v8.7.0/docs/sdk-model.attributedisplayformref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributeidentifier.html
+++ b/v8.7.0/docs/sdk-model.attributeidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributeinbucket.html
+++ b/v8.7.0/docs/sdk-model.attributeinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributelocalid.html
+++ b/v8.7.0/docs/sdk-model.attributelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributelocatorelement.html
+++ b/v8.7.0/docs/sdk-model.attributelocatorelement.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributelocatoridentifier.html
+++ b/v8.7.0/docs/sdk-model.attributelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributemodifications.html
+++ b/v8.7.0/docs/sdk-model.attributemodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributepredicate.html
+++ b/v8.7.0/docs/sdk-model.attributepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributesfind.html
+++ b/v8.7.0/docs/sdk-model.attributesfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.attributeuri.html
+++ b/v8.7.0/docs/sdk-model.attributeuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketattribute.html
+++ b/v8.7.0/docs/sdk-model.bucketattribute.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketattributeindex.html
+++ b/v8.7.0/docs/sdk-model.bucketattributeindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketattributes.html
+++ b/v8.7.0/docs/sdk-model.bucketattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketisempty.html
+++ b/v8.7.0/docs/sdk-model.bucketisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketitemlocalid.html
+++ b/v8.7.0/docs/sdk-model.bucketitemlocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketitemmodifications.html
+++ b/v8.7.0/docs/sdk-model.bucketitemmodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketitemreduce.html
+++ b/v8.7.0/docs/sdk-model.bucketitemreduce.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketitemreducer.html
+++ b/v8.7.0/docs/sdk-model.bucketitemreducer.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketitems.html
+++ b/v8.7.0/docs/sdk-model.bucketitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketmeasure.html
+++ b/v8.7.0/docs/sdk-model.bucketmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketmeasureindex.html
+++ b/v8.7.0/docs/sdk-model.bucketmeasureindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketmeasures.html
+++ b/v8.7.0/docs/sdk-model.bucketmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketmodifyitems.html
+++ b/v8.7.0/docs/sdk-model.bucketmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketpredicate.html
+++ b/v8.7.0/docs/sdk-model.bucketpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsattributes.html
+++ b/v8.7.0/docs/sdk-model.bucketsattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsbyid.html
+++ b/v8.7.0/docs/sdk-model.bucketsbyid.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsettotals.html
+++ b/v8.7.0/docs/sdk-model.bucketsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsfind.html
+++ b/v8.7.0/docs/sdk-model.bucketsfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsfindattribute.html
+++ b/v8.7.0/docs/sdk-model.bucketsfindattribute.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsfindmeasure.html
+++ b/v8.7.0/docs/sdk-model.bucketsfindmeasure.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsisempty.html
+++ b/v8.7.0/docs/sdk-model.bucketsisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsitems.html
+++ b/v8.7.0/docs/sdk-model.bucketsitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsmeasures.html
+++ b/v8.7.0/docs/sdk-model.bucketsmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsmodifyitem.html
+++ b/v8.7.0/docs/sdk-model.bucketsmodifyitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketsreduceitem.html
+++ b/v8.7.0/docs/sdk-model.bucketsreduceitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.bucketstotals.html
+++ b/v8.7.0/docs/sdk-model.bucketstotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.buckettotals.html
+++ b/v8.7.0/docs/sdk-model.buckettotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.colorpaletteitemtorgb.html
+++ b/v8.7.0/docs/sdk-model.colorpaletteitemtorgb.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.colorpalettetocolors.html
+++ b/v8.7.0/docs/sdk-model.colorpalettetocolors.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.comparatordirection.html
+++ b/v8.7.0/docs/sdk-model.comparatordirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.comparisonconditionoperator.html
+++ b/v8.7.0/docs/sdk-model.comparisonconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.computeratiorule.html
+++ b/v8.7.0/docs/sdk-model.computeratiorule.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dateattributegranularity.html
+++ b/v8.7.0/docs/sdk-model.dateattributegranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dategranularity.html
+++ b/v8.7.0/docs/sdk-model.dategranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defaultdimensionsgenerator.html
+++ b/v8.7.0/docs/sdk-model.defaultdimensionsgenerator.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.deffingerprint.html
+++ b/v8.7.0/docs/sdk-model.deffingerprint.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defsetdimensions.html
+++ b/v8.7.0/docs/sdk-model.defsetdimensions.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defsetexecconfig.html
+++ b/v8.7.0/docs/sdk-model.defsetexecconfig.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defsetpostprocessing.html
+++ b/v8.7.0/docs/sdk-model.defsetpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defsetsorts.html
+++ b/v8.7.0/docs/sdk-model.defsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.deftotals.html
+++ b/v8.7.0/docs/sdk-model.deftotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defwithdateformat.html
+++ b/v8.7.0/docs/sdk-model.defwithdateformat.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defwithdimensions.html
+++ b/v8.7.0/docs/sdk-model.defwithdimensions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defwithexecconfig.html
+++ b/v8.7.0/docs/sdk-model.defwithexecconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defwithfilters.html
+++ b/v8.7.0/docs/sdk-model.defwithfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defwithpostprocessing.html
+++ b/v8.7.0/docs/sdk-model.defwithpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.defwithsorting.html
+++ b/v8.7.0/docs/sdk-model.defwithsorting.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.deserializeobjref.html
+++ b/v8.7.0/docs/sdk-model.deserializeobjref.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dimensiongenerator.html
+++ b/v8.7.0/docs/sdk-model.dimensiongenerator.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dimensionitem.html
+++ b/v8.7.0/docs/sdk-model.dimensionitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dimensionsettotals.html
+++ b/v8.7.0/docs/sdk-model.dimensionsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dimensionsfinditem.html
+++ b/v8.7.0/docs/sdk-model.dimensionsfinditem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.dimensiontotals.html
+++ b/v8.7.0/docs/sdk-model.dimensiontotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.disablecomputeratio.html
+++ b/v8.7.0/docs/sdk-model.disablecomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.emptydef.html
+++ b/v8.7.0/docs/sdk-model.emptydef.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.factorynotationfor.html
+++ b/v8.7.0/docs/sdk-model.factorynotationfor.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.filterattributeelements.html
+++ b/v8.7.0/docs/sdk-model.filterattributeelements.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.filterattributeelements_1.html
+++ b/v8.7.0/docs/sdk-model.filterattributeelements_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.filterisempty.html
+++ b/v8.7.0/docs/sdk-model.filterisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.filtermeasureref.html
+++ b/v8.7.0/docs/sdk-model.filtermeasureref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.filterobjref.html
+++ b/v8.7.0/docs/sdk-model.filterobjref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.filterobjref_1.html
+++ b/v8.7.0/docs/sdk-model.filterobjref_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.guidtype.html
+++ b/v8.7.0/docs/sdk-model.guidtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.html
+++ b/v8.7.0/docs/sdk-model.html
@@ -439,7 +439,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
+++ b/v8.7.0/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iabsolutedatefilter.html
+++ b/v8.7.0/docs/sdk-model.iabsolutedatefilter.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iabsolutedatefiltervalues.from.html
+++ b/v8.7.0/docs/sdk-model.iabsolutedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iabsolutedatefiltervalues.html
+++ b/v8.7.0/docs/sdk-model.iabsolutedatefiltervalues.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iabsolutedatefiltervalues.to.html
+++ b/v8.7.0/docs/sdk-model.iabsolutedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
+++ b/v8.7.0/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iarithmeticmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.iarithmeticmeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattribute.attribute.html
+++ b/v8.7.0/docs/sdk-model.iattribute.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattribute.html
+++ b/v8.7.0/docs/sdk-model.iattribute.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributeelements.html
+++ b/v8.7.0/docs/sdk-model.iattributeelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributeelementsbyref.html
+++ b/v8.7.0/docs/sdk-model.iattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributeelementsbyref.uris.html
+++ b/v8.7.0/docs/sdk-model.iattributeelementsbyref.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributeelementsbyvalue.html
+++ b/v8.7.0/docs/sdk-model.iattributeelementsbyvalue.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributeelementsbyvalue.values.html
+++ b/v8.7.0/docs/sdk-model.iattributeelementsbyvalue.values.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributefilter.html
+++ b/v8.7.0/docs/sdk-model.iattributefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
+++ b/v8.7.0/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributelocatoritem.html
+++ b/v8.7.0/docs/sdk-model.iattributelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributeormeasure.html
+++ b/v8.7.0/docs/sdk-model.iattributeormeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributesortitem.attributesortitem.html
+++ b/v8.7.0/docs/sdk-model.iattributesortitem.attributesortitem.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iattributesortitem.html
+++ b/v8.7.0/docs/sdk-model.iattributesortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditable.html
+++ b/v8.7.0/docs/sdk-model.iauditable.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditabledates.created.html
+++ b/v8.7.0/docs/sdk-model.iauditabledates.created.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditabledates.html
+++ b/v8.7.0/docs/sdk-model.iauditabledates.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditabledates.updated.html
+++ b/v8.7.0/docs/sdk-model.iauditabledates.updated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditableusers.createdby.html
+++ b/v8.7.0/docs/sdk-model.iauditableusers.createdby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditableusers.html
+++ b/v8.7.0/docs/sdk-model.iauditableusers.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iauditableusers.updatedby.html
+++ b/v8.7.0/docs/sdk-model.iauditableusers.updatedby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ibucket.html
+++ b/v8.7.0/docs/sdk-model.ibucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ibucket.items.html
+++ b/v8.7.0/docs/sdk-model.ibucket.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ibucket.localidentifier.html
+++ b/v8.7.0/docs/sdk-model.ibucket.localidentifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ibucket.totals.html
+++ b/v8.7.0/docs/sdk-model.ibucket.totals.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolor.html
+++ b/v8.7.0/docs/sdk-model.icolor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorfrompalette.html
+++ b/v8.7.0/docs/sdk-model.icolorfrompalette.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorfrompalette.type.html
+++ b/v8.7.0/docs/sdk-model.icolorfrompalette.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorfrompalette.value.html
+++ b/v8.7.0/docs/sdk-model.icolorfrompalette.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolormappingitem.color.html
+++ b/v8.7.0/docs/sdk-model.icolormappingitem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolormappingitem.html
+++ b/v8.7.0/docs/sdk-model.icolormappingitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolormappingitem.id.html
+++ b/v8.7.0/docs/sdk-model.icolormappingitem.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorpalette.html
+++ b/v8.7.0/docs/sdk-model.icolorpalette.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorpaletteitem.fill.html
+++ b/v8.7.0/docs/sdk-model.icolorpaletteitem.fill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorpaletteitem.guid.html
+++ b/v8.7.0/docs/sdk-model.icolorpaletteitem.guid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icolorpaletteitem.html
+++ b/v8.7.0/docs/sdk-model.icolorpaletteitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icomparator.html
+++ b/v8.7.0/docs/sdk-model.icomparator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icomparisoncondition.comparison.html
+++ b/v8.7.0/docs/sdk-model.icomparisoncondition.comparison.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.icomparisoncondition.html
+++ b/v8.7.0/docs/sdk-model.icomparisoncondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idatefilter.html
+++ b/v8.7.0/docs/sdk-model.idatefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.identifier.html
+++ b/v8.7.0/docs/sdk-model.identifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.identifierref.html
+++ b/v8.7.0/docs/sdk-model.identifierref.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idimension.html
+++ b/v8.7.0/docs/sdk-model.idimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idimension.itemidentifiers.html
+++ b/v8.7.0/docs/sdk-model.idimension.itemidentifiers.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idimension.totals.html
+++ b/v8.7.0/docs/sdk-model.idimension.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idmatchattribute.html
+++ b/v8.7.0/docs/sdk-model.idmatchattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idmatchbucket.html
+++ b/v8.7.0/docs/sdk-model.idmatchbucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idmatchmeasure.html
+++ b/v8.7.0/docs/sdk-model.idmatchmeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.idref.html
+++ b/v8.7.0/docs/sdk-model.idref.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
+++ b/v8.7.0/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutionconfig.html
+++ b/v8.7.0/docs/sdk-model.iexecutionconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.attributes.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.attributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.buckets.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.buckets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.dimensions.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.dimensions.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.executionconfig.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.executionconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.filters.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.measures.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.postprocessing.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.postprocessing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.sortby.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iexecutiondefinition.workspace.html
+++ b/v8.7.0/docs/sdk-model.iexecutiondefinition.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ifilter.html
+++ b/v8.7.0/docs/sdk-model.ifilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iinsight.html
+++ b/v8.7.0/docs/sdk-model.iinsight.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iinsightdefinition.html
+++ b/v8.7.0/docs/sdk-model.iinsightdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ilocatoritem.html
+++ b/v8.7.0/docs/sdk-model.ilocatoritem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasure.html
+++ b/v8.7.0/docs/sdk-model.imeasure.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasure.measure.html
+++ b/v8.7.0/docs/sdk-model.imeasure.measure.html
@@ -24,7 +24,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.imeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuredefinition.measuredefinition.html
+++ b/v8.7.0/docs/sdk-model.imeasuredefinition.measuredefinition.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuredefinitiontype.html
+++ b/v8.7.0/docs/sdk-model.imeasuredefinitiontype.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasurefilter.html
+++ b/v8.7.0/docs/sdk-model.imeasurefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasurelocatoritem.html
+++ b/v8.7.0/docs/sdk-model.imeasurelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
+++ b/v8.7.0/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuresortitem.html
+++ b/v8.7.0/docs/sdk-model.imeasuresortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuresortitem.measuresortitem.html
+++ b/v8.7.0/docs/sdk-model.imeasuresortitem.measuresortitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuretitle.html
+++ b/v8.7.0/docs/sdk-model.imeasuretitle.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasuretitle.measure.html
+++ b/v8.7.0/docs/sdk-model.imeasuretitle.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasurevaluefilter.html
+++ b/v8.7.0/docs/sdk-model.imeasurevaluefilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
+++ b/v8.7.0/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.inegativeattributefilter.html
+++ b/v8.7.0/docs/sdk-model.inegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
+++ b/v8.7.0/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightattributes.html
+++ b/v8.7.0/docs/sdk-model.insightattributes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightbucket.html
+++ b/v8.7.0/docs/sdk-model.insightbucket.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightbuckets.html
+++ b/v8.7.0/docs/sdk-model.insightbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightcreated.html
+++ b/v8.7.0/docs/sdk-model.insightcreated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightcreatedby.html
+++ b/v8.7.0/docs/sdk-model.insightcreatedby.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightdisplayformusage.html
+++ b/v8.7.0/docs/sdk-model.insightdisplayformusage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightfilters.html
+++ b/v8.7.0/docs/sdk-model.insightfilters.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighthasattributes.html
+++ b/v8.7.0/docs/sdk-model.insighthasattributes.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighthasdatadefined.html
+++ b/v8.7.0/docs/sdk-model.insighthasdatadefined.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighthasmeasures.html
+++ b/v8.7.0/docs/sdk-model.insighthasmeasures.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightid.html
+++ b/v8.7.0/docs/sdk-model.insightid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightislocked.html
+++ b/v8.7.0/docs/sdk-model.insightislocked.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightitems.html
+++ b/v8.7.0/docs/sdk-model.insightitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightmeasures.html
+++ b/v8.7.0/docs/sdk-model.insightmeasures.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightmodifyitems.html
+++ b/v8.7.0/docs/sdk-model.insightmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightproperties.html
+++ b/v8.7.0/docs/sdk-model.insightproperties.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightreduceitems.html
+++ b/v8.7.0/docs/sdk-model.insightreduceitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightref.html
+++ b/v8.7.0/docs/sdk-model.insightref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightsanitize.html
+++ b/v8.7.0/docs/sdk-model.insightsanitize.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightsetbuckets.html
+++ b/v8.7.0/docs/sdk-model.insightsetbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightsetfilters.html
+++ b/v8.7.0/docs/sdk-model.insightsetfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightsetproperties.html
+++ b/v8.7.0/docs/sdk-model.insightsetproperties.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightsetsorts.html
+++ b/v8.7.0/docs/sdk-model.insightsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightsorts.html
+++ b/v8.7.0/docs/sdk-model.insightsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighttags.html
+++ b/v8.7.0/docs/sdk-model.insighttags.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighttitle.html
+++ b/v8.7.0/docs/sdk-model.insighttitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighttotals.html
+++ b/v8.7.0/docs/sdk-model.insighttotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightupdated.html
+++ b/v8.7.0/docs/sdk-model.insightupdated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insightupdatedby.html
+++ b/v8.7.0/docs/sdk-model.insightupdatedby.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.insighturi.html
+++ b/v8.7.0/docs/sdk-model.insighturi.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.inullablefilter.html
+++ b/v8.7.0/docs/sdk-model.inullablefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipopmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.ipopmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipositiveattributefilter.html
+++ b/v8.7.0/docs/sdk-model.ipositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
+++ b/v8.7.0/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipostprocessing.dateformat.html
+++ b/v8.7.0/docs/sdk-model.ipostprocessing.dateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipostprocessing.html
+++ b/v8.7.0/docs/sdk-model.ipostprocessing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperioddatedataset.dataset.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperioddatedataset.dataset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperioddatedataset.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperioddatedataset.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperioddatedatasetsimple.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperioddatedatasetsimple.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperiodmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperiodmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
+++ b/v8.7.0/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irangecondition.html
+++ b/v8.7.0/docs/sdk-model.irangecondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irangecondition.range.html
+++ b/v8.7.0/docs/sdk-model.irangecondition.range.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irankingfilter.html
+++ b/v8.7.0/docs/sdk-model.irankingfilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irankingfilter.rankingfilter.html
+++ b/v8.7.0/docs/sdk-model.irankingfilter.rankingfilter.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irelativedatefilter.html
+++ b/v8.7.0/docs/sdk-model.irelativedatefilter.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irelativedatefiltervalues.from.html
+++ b/v8.7.0/docs/sdk-model.irelativedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irelativedatefiltervalues.granularity.html
+++ b/v8.7.0/docs/sdk-model.irelativedatefiltervalues.granularity.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irelativedatefiltervalues.html
+++ b/v8.7.0/docs/sdk-model.irelativedatefiltervalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irelativedatefiltervalues.to.html
+++ b/v8.7.0/docs/sdk-model.irelativedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolor.html
+++ b/v8.7.0/docs/sdk-model.irgbcolor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolor.type.html
+++ b/v8.7.0/docs/sdk-model.irgbcolor.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolor.value.html
+++ b/v8.7.0/docs/sdk-model.irgbcolor.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolorvalue.b.html
+++ b/v8.7.0/docs/sdk-model.irgbcolorvalue.b.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolorvalue.g.html
+++ b/v8.7.0/docs/sdk-model.irgbcolorvalue.g.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolorvalue.html
+++ b/v8.7.0/docs/sdk-model.irgbcolorvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.irgbcolorvalue.r.html
+++ b/v8.7.0/docs/sdk-model.irgbcolorvalue.r.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isabsolutedatefilter.html
+++ b/v8.7.0/docs/sdk-model.isabsolutedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isadhocmeasure.html
+++ b/v8.7.0/docs/sdk-model.isadhocmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isalltimedatefilter.html
+++ b/v8.7.0/docs/sdk-model.isalltimedatefilter.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isarithmeticmeasure.html
+++ b/v8.7.0/docs/sdk-model.isarithmeticmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isarithmeticmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.isarithmeticmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattribute.html
+++ b/v8.7.0/docs/sdk-model.isattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattributeareasort.html
+++ b/v8.7.0/docs/sdk-model.isattributeareasort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattributeelementsbyref.html
+++ b/v8.7.0/docs/sdk-model.isattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattributeelementsbyvalue.html
+++ b/v8.7.0/docs/sdk-model.isattributeelementsbyvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattributefilter.html
+++ b/v8.7.0/docs/sdk-model.isattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattributelocator.html
+++ b/v8.7.0/docs/sdk-model.isattributelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isattributesort.html
+++ b/v8.7.0/docs/sdk-model.isattributesort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isbucket.html
+++ b/v8.7.0/docs/sdk-model.isbucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iscolorfrompalette.html
+++ b/v8.7.0/docs/sdk-model.iscolorfrompalette.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iscomparisoncondition.html
+++ b/v8.7.0/docs/sdk-model.iscomparisoncondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iscomparisonconditionoperator.html
+++ b/v8.7.0/docs/sdk-model.iscomparisonconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isdatefilter.html
+++ b/v8.7.0/docs/sdk-model.isdatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isdimension.html
+++ b/v8.7.0/docs/sdk-model.isdimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isfilter.html
+++ b/v8.7.0/docs/sdk-model.isfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isidentifierref.html
+++ b/v8.7.0/docs/sdk-model.isidentifierref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isinsight.html
+++ b/v8.7.0/docs/sdk-model.isinsight.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.islocalidref.html
+++ b/v8.7.0/docs/sdk-model.islocalidref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ismeasure.html
+++ b/v8.7.0/docs/sdk-model.ismeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ismeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.ismeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ismeasureformatinpercent.html
+++ b/v8.7.0/docs/sdk-model.ismeasureformatinpercent.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ismeasurelocator.html
+++ b/v8.7.0/docs/sdk-model.ismeasurelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ismeasuresort.html
+++ b/v8.7.0/docs/sdk-model.ismeasuresort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ismeasurevaluefilter.html
+++ b/v8.7.0/docs/sdk-model.ismeasurevaluefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isnegativeattributefilter.html
+++ b/v8.7.0/docs/sdk-model.isnegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isobjref.html
+++ b/v8.7.0/docs/sdk-model.isobjref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isortitem.html
+++ b/v8.7.0/docs/sdk-model.isortitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ispopmeasure.html
+++ b/v8.7.0/docs/sdk-model.ispopmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ispopmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.ispopmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ispositiveattributefilter.html
+++ b/v8.7.0/docs/sdk-model.ispositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ispreviousperiodmeasure.html
+++ b/v8.7.0/docs/sdk-model.ispreviousperiodmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ispreviousperiodmeasuredefinition.html
+++ b/v8.7.0/docs/sdk-model.ispreviousperiodmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.israngecondition.html
+++ b/v8.7.0/docs/sdk-model.israngecondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.israngeconditionoperator.html
+++ b/v8.7.0/docs/sdk-model.israngeconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isrankingfilter.html
+++ b/v8.7.0/docs/sdk-model.isrankingfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isrelativedatefilter.html
+++ b/v8.7.0/docs/sdk-model.isrelativedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isrgbcolor.html
+++ b/v8.7.0/docs/sdk-model.isrgbcolor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.issimplemeasure.html
+++ b/v8.7.0/docs/sdk-model.issimplemeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.istotal.html
+++ b/v8.7.0/docs/sdk-model.istotal.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.isuriref.html
+++ b/v8.7.0/docs/sdk-model.isuriref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.itemindimension.html
+++ b/v8.7.0/docs/sdk-model.itemindimension.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.itotal.alias.html
+++ b/v8.7.0/docs/sdk-model.itotal.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.itotal.attributeidentifier.html
+++ b/v8.7.0/docs/sdk-model.itotal.attributeidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.itotal.html
+++ b/v8.7.0/docs/sdk-model.itotal.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.itotal.measureidentifier.html
+++ b/v8.7.0/docs/sdk-model.itotal.measureidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.itotal.type.html
+++ b/v8.7.0/docs/sdk-model.itotal.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.email.html
+++ b/v8.7.0/docs/sdk-model.iuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.firstname.html
+++ b/v8.7.0/docs/sdk-model.iuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.fullname.html
+++ b/v8.7.0/docs/sdk-model.iuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.html
+++ b/v8.7.0/docs/sdk-model.iuser.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.lastname.html
+++ b/v8.7.0/docs/sdk-model.iuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.login.html
+++ b/v8.7.0/docs/sdk-model.iuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.iuser.ref.html
+++ b/v8.7.0/docs/sdk-model.iuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ivisualizationclass.html
+++ b/v8.7.0/docs/sdk-model.ivisualizationclass.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.ivisualizationclass.visualizationclass.html
+++ b/v8.7.0/docs/sdk-model.ivisualizationclass.visualizationclass.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.localidref.html
+++ b/v8.7.0/docs/sdk-model.localidref.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureaggregation.html
+++ b/v8.7.0/docs/sdk-model.measureaggregation.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurealias.html
+++ b/v8.7.0/docs/sdk-model.measurealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurearithmeticoperands.html
+++ b/v8.7.0/docs/sdk-model.measurearithmeticoperands.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurearithmeticoperands_1.html
+++ b/v8.7.0/docs/sdk-model.measurearithmeticoperands_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurearithmeticoperator.html
+++ b/v8.7.0/docs/sdk-model.measurearithmeticoperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurearithmeticoperator_1.html
+++ b/v8.7.0/docs/sdk-model.measurearithmeticoperator_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.aggregation.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.aggregation.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.builddefinition.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.defaultaggregation.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.defaultaggregation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.filters.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.generatelocalid.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.measureitem.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.measureitem.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.nofilters.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.nofilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.noratio.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.noratio.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilder.ratio.html
+++ b/v8.7.0/docs/sdk-model.measurebuilder.ratio.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.alias.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.build.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.build.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.builddefinition.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.builddefinition.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.customlocalid.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.customlocalid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.defaultformat.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.defaultformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.defaultlocalid.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.format.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.format.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.generatelocalid.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.generatelocalid.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.initializefromexisting.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.initializefromexisting.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.localid.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.noalias.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.notitle.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.notitle.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurebuilderbase.title.html
+++ b/v8.7.0/docs/sdk-model.measurebuilderbase.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measuredoescomputeratio.html
+++ b/v8.7.0/docs/sdk-model.measuredoescomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureenvelope.html
+++ b/v8.7.0/docs/sdk-model.measureenvelope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurefilters.html
+++ b/v8.7.0/docs/sdk-model.measurefilters.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureformat.html
+++ b/v8.7.0/docs/sdk-model.measureformat.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measuregroupidentifier.html
+++ b/v8.7.0/docs/sdk-model.measuregroupidentifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureidentifier.html
+++ b/v8.7.0/docs/sdk-model.measureidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureinbucket.html
+++ b/v8.7.0/docs/sdk-model.measureinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureitem.html
+++ b/v8.7.0/docs/sdk-model.measureitem.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureitem_1.html
+++ b/v8.7.0/docs/sdk-model.measureitem_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurelocalid.html
+++ b/v8.7.0/docs/sdk-model.measurelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurelocatoridentifier.html
+++ b/v8.7.0/docs/sdk-model.measurelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measuremasteridentifier.html
+++ b/v8.7.0/docs/sdk-model.measuremasteridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measuremasteridentifier_1.html
+++ b/v8.7.0/docs/sdk-model.measuremasteridentifier_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measuremodifications.html
+++ b/v8.7.0/docs/sdk-model.measuremodifications.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureorlocalid.html
+++ b/v8.7.0/docs/sdk-model.measureorlocalid.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurepopattribute.html
+++ b/v8.7.0/docs/sdk-model.measurepopattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurepopattribute_1.html
+++ b/v8.7.0/docs/sdk-model.measurepopattribute_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurepredicate.html
+++ b/v8.7.0/docs/sdk-model.measurepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurepreviousperioddatedatasets.html
+++ b/v8.7.0/docs/sdk-model.measurepreviousperioddatedatasets.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurepreviousperioddatedatasets_1.html
+++ b/v8.7.0/docs/sdk-model.measurepreviousperioddatedatasets_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measuretitle.html
+++ b/v8.7.0/docs/sdk-model.measuretitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measureuri.html
+++ b/v8.7.0/docs/sdk-model.measureuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurevaluefiltercondition.html
+++ b/v8.7.0/docs/sdk-model.measurevaluefiltercondition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurevaluefiltermeasure.html
+++ b/v8.7.0/docs/sdk-model.measurevaluefiltermeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.measurevaluefilteroperator.html
+++ b/v8.7.0/docs/sdk-model.measurevaluefilteroperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.modifyattribute.html
+++ b/v8.7.0/docs/sdk-model.modifyattribute.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.modifymeasure.html
+++ b/v8.7.0/docs/sdk-model.modifymeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.modifypopmeasure.html
+++ b/v8.7.0/docs/sdk-model.modifypopmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.modifypreviousperiodmeasure.html
+++ b/v8.7.0/docs/sdk-model.modifypreviousperiodmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.modifysimplemeasure.html
+++ b/v8.7.0/docs/sdk-model.modifysimplemeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newabsolutedatefilter.html
+++ b/v8.7.0/docs/sdk-model.newabsolutedatefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newalltimefilter.html
+++ b/v8.7.0/docs/sdk-model.newalltimefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newarithmeticmeasure.html
+++ b/v8.7.0/docs/sdk-model.newarithmeticmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newattribute.html
+++ b/v8.7.0/docs/sdk-model.newattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newattributeareasort.html
+++ b/v8.7.0/docs/sdk-model.newattributeareasort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newattributelocator.html
+++ b/v8.7.0/docs/sdk-model.newattributelocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newattributesort.html
+++ b/v8.7.0/docs/sdk-model.newattributesort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newbucket.html
+++ b/v8.7.0/docs/sdk-model.newbucket.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newdefforbuckets.html
+++ b/v8.7.0/docs/sdk-model.newdefforbuckets.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newdefforinsight.html
+++ b/v8.7.0/docs/sdk-model.newdefforinsight.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newdefforitems.html
+++ b/v8.7.0/docs/sdk-model.newdefforitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newdimension.html
+++ b/v8.7.0/docs/sdk-model.newdimension.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newmeasure.html
+++ b/v8.7.0/docs/sdk-model.newmeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newmeasuresort.html
+++ b/v8.7.0/docs/sdk-model.newmeasuresort.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newmeasurevaluefilter.html
+++ b/v8.7.0/docs/sdk-model.newmeasurevaluefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newmeasurevaluefilter_1.html
+++ b/v8.7.0/docs/sdk-model.newmeasurevaluefilter_1.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newnegativeattributefilter.html
+++ b/v8.7.0/docs/sdk-model.newnegativeattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newpopmeasure.html
+++ b/v8.7.0/docs/sdk-model.newpopmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newpositiveattributefilter.html
+++ b/v8.7.0/docs/sdk-model.newpositiveattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newpreviousperiodmeasure.html
+++ b/v8.7.0/docs/sdk-model.newpreviousperiodmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newrankingfilter.html
+++ b/v8.7.0/docs/sdk-model.newrankingfilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newrankingfilter_1.html
+++ b/v8.7.0/docs/sdk-model.newrankingfilter_1.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newrelativedatefilter.html
+++ b/v8.7.0/docs/sdk-model.newrelativedatefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newtotal.html
+++ b/v8.7.0/docs/sdk-model.newtotal.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.newtwodimensional.html
+++ b/v8.7.0/docs/sdk-model.newtwodimensional.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.objecttype.html
+++ b/v8.7.0/docs/sdk-model.objecttype.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.objref.html
+++ b/v8.7.0/docs/sdk-model.objref.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.objrefinscope.html
+++ b/v8.7.0/docs/sdk-model.objrefinscope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.popmeasurebuilder.builddefinition.html
+++ b/v8.7.0/docs/sdk-model.popmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.popmeasurebuilder.generatelocalid.html
+++ b/v8.7.0/docs/sdk-model.popmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.popmeasurebuilder.html
+++ b/v8.7.0/docs/sdk-model.popmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.popmeasurebuilder.mastermeasure.html
+++ b/v8.7.0/docs/sdk-model.popmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.popmeasurebuilder.popattribute.html
+++ b/v8.7.0/docs/sdk-model.popmeasurebuilder.popattribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.popmeasurebuilderinput.html
+++ b/v8.7.0/docs/sdk-model.popmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
+++ b/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
+++ b/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
+++ b/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.html
+++ b/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
+++ b/v8.7.0/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.previousperiodmeasurebuilderinput.html
+++ b/v8.7.0/docs/sdk-model.previousperiodmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.rangeconditionoperator.html
+++ b/v8.7.0/docs/sdk-model.rangeconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.rankingfilteroperator.html
+++ b/v8.7.0/docs/sdk-model.rankingfilteroperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.relativedatefiltervalues.html
+++ b/v8.7.0/docs/sdk-model.relativedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.rgbtype.html
+++ b/v8.7.0/docs/sdk-model.rgbtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.serializeobjref.html
+++ b/v8.7.0/docs/sdk-model.serializeobjref.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.sortdirection.html
+++ b/v8.7.0/docs/sdk-model.sortdirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.sortentityids.html
+++ b/v8.7.0/docs/sdk-model.sortentityids.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.sortmeasurelocators.html
+++ b/v8.7.0/docs/sdk-model.sortmeasurelocators.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.totalisnative.html
+++ b/v8.7.0/docs/sdk-model.totalisnative.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.totaltype.html
+++ b/v8.7.0/docs/sdk-model.totaltype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.uri.html
+++ b/v8.7.0/docs/sdk-model.uri.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.uriref.html
+++ b/v8.7.0/docs/sdk-model.uriref.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.userfullname.html
+++ b/v8.7.0/docs/sdk-model.userfullname.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.visclassid.html
+++ b/v8.7.0/docs/sdk-model.visclassid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.visclassuri.html
+++ b/v8.7.0/docs/sdk-model.visclassuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.visclassurl.html
+++ b/v8.7.0/docs/sdk-model.visclassurl.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-model.visualizationproperties.html
+++ b/v8.7.0/docs/sdk-model.visualizationproperties.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.areachart.html
+++ b/v8.7.0/docs/sdk-ui-charts.areachart.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.axisnameposition.html
+++ b/v8.7.0/docs/sdk-ui-charts.axisnameposition.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.barchart.html
+++ b/v8.7.0/docs/sdk-ui-charts.barchart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.bubblechart.html
+++ b/v8.7.0/docs/sdk-ui-charts.bubblechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.bulletchart.html
+++ b/v8.7.0/docs/sdk-ui-charts.bulletchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.chartaligntypes.html
+++ b/v8.7.0/docs/sdk-ui-charts.chartaligntypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.columnchart.html
+++ b/v8.7.0/docs/sdk-ui-charts.columnchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.combochart.html
+++ b/v8.7.0/docs/sdk-ui-charts.combochart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.donutchart.html
+++ b/v8.7.0/docs/sdk-ui-charts.donutchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.funnelchart.html
+++ b/v8.7.0/docs/sdk-ui-charts.funnelchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.headline.html
+++ b/v8.7.0/docs/sdk-ui-charts.headline.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.heatmap.html
+++ b/v8.7.0/docs/sdk-ui-charts.heatmap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.html
+++ b/v8.7.0/docs/sdk-ui-charts.html
@@ -164,7 +164,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iareachartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iareachartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.format.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.format.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.max.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.max.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.min.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.min.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.name.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.name.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.rotation.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.rotation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisconfig.visible.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisnameconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisnameconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisnameconfig.position.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisnameconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iaxisnameconfig.visible.html
+++ b/v8.7.0/docs/sdk-ui-charts.iaxisnameconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibarchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibarchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibubblechartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibubblechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibucketchartprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibucketchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibucketchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibucketchartprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibucketchartprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibucketchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ibulletchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ibulletchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartcallbacks.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartcallbacks.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.colormapping.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.colormapping.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.colorpalette.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.colorpalette.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.colors.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.colors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.datalabels.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.datalabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.datapoints.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.datapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.dualaxis.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.dualaxis.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.grid.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.grid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.html
@@ -111,7 +111,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.legend.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.legend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.legendlayout.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.legendlayout.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.separators.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.xaxis.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.xformat.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.xformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.xlabel.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.xlabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.yaxis.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.yformat.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.yformat.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.ylabel.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.ylabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartconfig.zoominsight.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartconfig.zoominsight.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartlimits.categories.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartlimits.categories.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartlimits.datapoints.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartlimits.datapoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartlimits.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartlimits.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ichartlimits.series.html
+++ b/v8.7.0/docs/sdk-ui-charts.ichartlimits.series.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icolumnchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.icolumnchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icombochartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.icombochartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icommonchartprops.config.html
+++ b/v8.7.0/docs/sdk-ui-charts.icommonchartprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icommonchartprops.execconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.icommonchartprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icommonchartprops.height.html
+++ b/v8.7.0/docs/sdk-ui-charts.icommonchartprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icommonchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.icommonchartprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.icommonchartprops.width.html
+++ b/v8.7.0/docs/sdk-ui-charts.icommonchartprops.width.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idatalabelsconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.idatalabelsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idatalabelsconfig.visible.html
+++ b/v8.7.0/docs/sdk-ui-charts.idatalabelsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idatalabelsvisible.html
+++ b/v8.7.0/docs/sdk-ui-charts.idatalabelsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idatapointsconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.idatapointsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idatapointsconfig.visible.html
+++ b/v8.7.0/docs/sdk-ui-charts.idatapointsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idatapointsvisible.html
+++ b/v8.7.0/docs/sdk-ui-charts.idatapointsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.idonutchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.idonutchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ifunnelchartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ifunnelchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.igridconfig.enabled.html
+++ b/v8.7.0/docs/sdk-ui-charts.igridconfig.enabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.igridconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.igridconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheadlineprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheadlineprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iheatmapprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iheatmapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegendconfig.enabled.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegendconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegendconfig.position.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegendconfig.responsive.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegenddata.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegenddata.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegenddata.legenditems.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegenddata.legenditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegenditem.color.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegenditem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegenditem.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegenditem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegenditem.name.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegenditem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilegenditem.onclick.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilegenditem.onclick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ilinechartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ilinechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ipiechartprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ipiechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.iscatterplotprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.iscatterplotprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itooltipconfig.enabled.html
+++ b/v8.7.0/docs/sdk-ui-charts.itooltipconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itooltipconfig.html
+++ b/v8.7.0/docs/sdk-ui-charts.itooltipconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.itreemapprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.itreemapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
+++ b/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.measure.html
+++ b/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.ixirrprops.html
+++ b/v8.7.0/docs/sdk-ui-charts.ixirrprops.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.linechart.html
+++ b/v8.7.0/docs/sdk-ui-charts.linechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.onlegendready.html
+++ b/v8.7.0/docs/sdk-ui-charts.onlegendready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.piechart.html
+++ b/v8.7.0/docs/sdk-ui-charts.piechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.positiontype.html
+++ b/v8.7.0/docs/sdk-ui-charts.positiontype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.scatterplot.html
+++ b/v8.7.0/docs/sdk-ui-charts.scatterplot.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.treemap.html
+++ b/v8.7.0/docs/sdk-ui-charts.treemap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.viewbyattributeslimit.html
+++ b/v8.7.0/docs/sdk-ui-charts.viewbyattributeslimit.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-charts.xirr.html
+++ b/v8.7.0/docs/sdk-ui-charts.xirr.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.anydashboardeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.anydashboardeventhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.anyeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.anyeventhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.commandprocessingmeta.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.commandprocessingmeta.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.customdashboardinsightcomponent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.customdashboardinsightcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.customdashboardkpicomponent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.customdashboardkpicomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.customdashboardwidgetcomponent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.customdashboardwidgetcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardcommands.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardcommands.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardcommandtype.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardcommandtype.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardconfig.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardcontext.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardcontext.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardcopysaved.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardcopysaved.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardcopysaved.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardcopysaved.payload.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardcopysaved.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardcopysaved.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboarddescriptor.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboarddescriptor.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboarddispatch.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboarddispatch.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboarddrilldefinition.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboarddrilldefinition.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardeventbody.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardeventbody.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardeventevalfn.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardeventevalfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardeventhandler.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardeventhandlerfn.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardeventhandlerfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardevents.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardevents.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardeventtype.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardeventtype.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardinitialized.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardinitialized.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardinitialized.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardinitialized.payload.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardinitialized.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardinitialized.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardmodelcustomizationfns.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardmodelcustomizationfns.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardplugindescriptor.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardplugindescriptor.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1._pluginversion.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1._pluginversion.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.author.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.author.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.displayname.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.displayname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.maxengineversion.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.maxengineversion.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.minengineversion.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.minengineversion.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.register.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.register.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.version.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardpluginv1.version.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardselector.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardselector.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardselectorevaluator.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardselectorevaluator.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardstatechangecallback.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardstatechangecallback.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.dashboardtransformfn.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.dashboardtransformfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.datefilterconfigvalidationresult.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.datefilterconfigvalidationresult.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationfailed.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationfailed.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationfailed.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationfailed.payload.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationfailed.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationfailed.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationresult.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.datefiltervalidationresult.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.defaultdashboardinsight.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.defaultdashboardinsight.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.defaultdashboardkpi.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.defaultdashboardkpi.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.defaultdashboardthememodifier.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.defaultdashboardthememodifier.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.extendeddashboarditem.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.extendeddashboarditem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.extendeddashboarditemtype.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.extendeddashboarditemtype.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.extendeddashboarditemtypes.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.extendeddashboarditemtypes.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.extendeddashboardlayoutsection.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.extendeddashboardlayoutsection.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.extendeddashboardwidget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.extendeddashboardwidget.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.fluidlayoutcustomizationfn.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.fluidlayoutcustomizationfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.html
@@ -249,7 +249,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.ctx.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.ctx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.meta.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.meta.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.payload.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomdashboardevent.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomwidget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomwidget.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetbase.customtype.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetbase.customtype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetbase.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetbase.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetbase.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetbase.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetdefinition.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.icustomwidgetdefinition.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.config.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.config.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.dashboard.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.dashboard.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.filtercontextref.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.filtercontextref.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.permissions.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.permissions.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardbaseprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.correlationid.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.correlationid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.meta.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.meta.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcommand.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.insightcomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.insightcomponentprovider.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.kpicomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.kpicomponentprovider.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.widgetcomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.widgetcomponentprovider.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizationprops.customizationfns.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizationprops.customizationfns.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizationprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizationprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.customwidgets.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.customwidgets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.insightwidgets.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.insightwidgets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.kpiwidgets.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.kpiwidgets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.layout.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardcustomizer.layout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboarddrillevent.drilldefinitions.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboarddrillevent.drilldefinitions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboarddrillevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboarddrillevent.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboarddrillevent.widgetref.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboarddrillevent.widgetref.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.getdashboardcomponent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.getdashboardcomponent.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.initializeplugins.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.initializeplugins.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.version.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardengine.version.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.correlationid.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.correlationid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.ctx.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.ctx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.meta.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.meta.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.payload.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardevent.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.addcustomeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.addcustomeventhandler.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.addeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.addeventhandler.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.removecustomeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.removecustomeventhandler.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.removeeventhandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.removeeventhandler.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.subscribetostatechanges.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.subscribetostatechanges.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.unsubscribefromstatechanges.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventhandling.unsubscribefromstatechanges.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.eventhandlers.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.eventhandlers.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.oneventinginitialized.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.oneventinginitialized.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.onstatechange.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardeventing.onstatechange.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardextensionprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardextensionprops.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardfilter.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardfilter.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomdecorator.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomdecorator.html
@@ -56,7 +56,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomprovider.html
@@ -38,7 +38,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withtag.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withtag.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightprops.insight.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightprops.insight.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightprops.widget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardinsightprops.widget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpicustomizer.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpicustomizer.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomdecorator.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomdecorator.html
@@ -56,7 +56,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomprovider.html
@@ -36,7 +36,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.alert.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.alert.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.kpiwidget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardkpiprops.kpiwidget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.customizefluidlayout.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.customizefluidlayout.html
@@ -37,7 +37,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1._pluginversion.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1._pluginversion.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginloaded.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginloaded.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginunload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginunload.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.register.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardplugincontract_v1.register.html
@@ -39,7 +39,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardprops.children.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardprops.children.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.disablethemeloading.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.disablethemeloading.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.theme.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.theme.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.thememodifier.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardthemingprops.thememodifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.addcustomwidget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.addcustomwidget.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.datedataset.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.datedataset.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.ignoredattributefilters.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.ignoredattributefilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.widget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idashboardwidgetprops.widget.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.origin.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.origin.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.target.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.target.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.idrilldowndefinition.type.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.additem.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.additem.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.addsection.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.addsection.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.initializedashboard.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.initializedashboard.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.initializedashboard.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.initializedashboard.payload.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.initializedashboard.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.initializedashboard.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.initialloadcorrelationid.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.initialloadcorrelationid.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.insightcomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.insightcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.iscustomdashboardevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.iscustomdashboardevent.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.iscustomwidget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.iscustomwidget.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.iscustomwidgetdefinition.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.iscustomwidgetdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.isdashboardevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.isdashboardevent.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.isdashboardeventorcustomdashboardevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.isdashboardeventorcustomdashboardevent.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.isdrilldowndefinition.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.isdrilldowndefinition.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.kpicomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.kpicomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.newcustomwidget.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.newcustomwidget.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.newdashboardengine.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.newdashboardengine.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.newdashboarditem.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.newdashboarditem.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.newdashboardsection.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.newdashboardsection.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.objectavailabilityconfig.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.objectavailabilityconfig.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.onfireddashboardviewdrillevent.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.onfireddashboardviewdrillevent.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.optionalinsightcomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.optionalinsightcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.optionalkpicomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.optionalkpicomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.optionalprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.optionalprovider.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.optionalwidgetcomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.optionalwidgetcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.resolveddashboardconfig.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.resolveddashboardconfig.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.savedashboardas.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.savedashboardas.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.savedashboardas.payload.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.savedashboardas.payload.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.savedashboardas.type.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.savedashboardas.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectbackendcapabilities.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectbackendcapabilities.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectcatalogattributedisplayforms.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectcatalogattributedisplayforms.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectcatalogattributes.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectcatalogattributes.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectcatalogdatedatasets.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectcatalogdatedatasets.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectcatalogfacts.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectcatalogfacts.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectcatalogmeasures.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectcatalogmeasures.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectcolorpalette.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectcolorpalette.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectconfig.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboarddescription.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboarddescription.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboardid.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboardid.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboardidref.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboardidref.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboardref.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboardref.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboardtags.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboardtags.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboardtitle.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboardtitle.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboarduri.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboarduri.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdashboarduriref.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdashboarduriref.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdatefilterconfig.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdatefilterconfig.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdateformat.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdateformat.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectdisabledefaultdrills.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectdisabledefaultdrills.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenableclickableattributeurl.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenableclickableattributeurl.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablecompanylogoinembeddedui.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablecompanylogoinembeddedui.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablefiltervaluesresolutionindrillevents.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablefiltervaluesresolutionindrillevents.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltodashboard.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltodashboard.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltoinsight.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltoinsight.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltourl.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltourl.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardexportpdf.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardexportpdf.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardimplicitdrilldown.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardimplicitdrilldown.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardsaveasnew.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardsaveasnew.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardschedule.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardschedule.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardschedulerecipients.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectenablekpidashboardschedulerecipients.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selecthidekpidrillinembedded.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selecthidekpidrillinembedded.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectinsights.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectinsights.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectisdashboardsaving.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectisdashboardsaving.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectisembedded.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectisembedded.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectisreadonly.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectisreadonly.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectlocale.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectlocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectobjectavailabilityconfig.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectobjectavailabilityconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectpermissions.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectpermissions.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectplatformedition.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectplatformedition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectseparators.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectseparators.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.selectsettings.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.selectsettings.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.singleeventtypehandler.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.singleeventtypehandler.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-dashboard.widgetcomponentprovider.html
+++ b/v8.7.0/docs/sdk-ui-dashboard.widgetcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.absolutedatefilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.absolutedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.attributeelements.html
+++ b/v8.7.0/docs/sdk-ui-filters.attributeelements.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.attributefilter.html
+++ b/v8.7.0/docs/sdk-ui-filters.attributefilter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.attributefilterbutton.html
+++ b/v8.7.0/docs/sdk-ui-filters.attributefilterbutton.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.attributelistitem.html
+++ b/v8.7.0/docs/sdk-ui-filters.attributelistitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilter._constructor_.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilter._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilter.componentdidmount.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilter.componentdidmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilter.defaultprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilter.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilter.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilter.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilter.render.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilter.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilterhelpers.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilterhelpers.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
+++ b/v8.7.0/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.defaultdatefilteroptions.html
+++ b/v8.7.0/docs/sdk-ui-filters.defaultdatefilteroptions.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.emptylistitem.empty.html
+++ b/v8.7.0/docs/sdk-ui-filters.emptylistitem.empty.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.emptylistitem.html
+++ b/v8.7.0/docs/sdk-ui-filters.emptylistitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
+++ b/v8.7.0/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.granularityintlkey.html
+++ b/v8.7.0/docs/sdk-ui-filters.granularityintlkey.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.html
+++ b/v8.7.0/docs/sdk-ui-filters.html
@@ -168,7 +168,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.attributefilterref.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.attributefilterref.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.deletefilter.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.deletefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.iselementsloading.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.iselementsloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.isloaded.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.isloaded.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.ismobile.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.ismobile.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.listitemclass.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.listitemclass.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.maxselectionsize.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.maxselectionsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.onconfigurationchange.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.onconfigurationchange.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showconfigurationbutton.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showconfigurationbutton.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showdeletebutton.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showdeletebutton.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.width.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.applydisabled.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.applydisabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.error.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.error.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isfullwidth.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isfullwidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isinverted.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isinverted.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isloading.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.items.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onapplybuttonclicked.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onapplybuttonclicked.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onclosebuttonclicked.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onclosebuttonclicked.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onrangechange.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onrangechange.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onsearch.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onsearch.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onselect.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.onselect.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.parentfiltertitles.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.parentfiltertitles.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.searchstring.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.searchstring.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.selecteditems.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.selecteditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.showitemsfilteredmessage.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.showitemsfilteredmessage.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.totalcount.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownbodyprops.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.ref.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.title.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.type.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownitem.type.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.isloading.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseout.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseout.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseover.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseover.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.ononly.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.ononly.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onselect.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.onselect.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.selected.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.selected.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.source.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributedropdownlistitemprops.source.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.error.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.error.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.children.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.children.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.limit.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.offset.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.options.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.renderbody.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.renderbody.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterbuttonprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.filter.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.identifier.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.locale.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.onapply.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.onerror.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.title.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-filters.iattributefilterprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.icustomgranularityselection.enable.html
+++ b/v8.7.0/docs/sdk-ui-filters.icustomgranularityselection.enable.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.icustomgranularityselection.html
+++ b/v8.7.0/docs/sdk-ui-filters.icustomgranularityselection.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
+++ b/v8.7.0/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idateandmessagetranslator.html
+++ b/v8.7.0/docs/sdk-ui-filters.idateandmessagetranslator.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.locale.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterownprops.locale.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterprops.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstate.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstate.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatetranslator.formatdate.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatetranslator.formatdate.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.idatetranslator.html
+++ b/v8.7.0/docs/sdk-ui-filters.idatetranslator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
+++ b/v8.7.0/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iextendeddatefiltererrors.html
+++ b/v8.7.0/docs/sdk-ui-filters.iextendeddatefiltererrors.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
+++ b/v8.7.0/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.title.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasuredropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterstate.html
+++ b/v8.7.0/docs/sdk-ui-filters.imeasurevaluefilterstate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imessagetranslator.formatmessage.html
+++ b/v8.7.0/docs/sdk-ui-filters.imessagetranslator.formatmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.imessagetranslator.html
+++ b/v8.7.0/docs/sdk-ui-filters.imessagetranslator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.filter.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.locale.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.onapply.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
+++ b/v8.7.0/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.isabsolutedatefilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.isabsolutedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.isemptylistitem.html
+++ b/v8.7.0/docs/sdk-ui-filters.isemptylistitem.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.isnonemptylistitem.html
+++ b/v8.7.0/docs/sdk-ui-filters.isnonemptylistitem.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.isrelativedatefilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.isrelativedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.isuirelativedatefilterform.html
+++ b/v8.7.0/docs/sdk-ui-filters.isuirelativedatefilterform.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
+++ b/v8.7.0/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.iwarningmessage.html
+++ b/v8.7.0/docs/sdk-ui-filters.iwarningmessage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.render.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.state.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilter.state.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilterdropdown.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilterdropdown.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
+++ b/v8.7.0/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.rankingfilter.html
+++ b/v8.7.0/docs/sdk-ui-filters.rankingfilter.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.rankingfilterdropdown.html
+++ b/v8.7.0/docs/sdk-ui-filters.rankingfilterdropdown.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.relativedatefilteroption.html
+++ b/v8.7.0/docs/sdk-ui-filters.relativedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-filters.warningmessage.html
+++ b/v8.7.0/docs/sdk-ui-filters.warningmessage.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.centerpositionchangedcallback.html
+++ b/v8.7.0/docs/sdk-ui-geo.centerpositionchangedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.geopushpinchart.html
+++ b/v8.7.0/docs/sdk-ui-geo.geopushpinchart.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.html
+++ b/v8.7.0/docs/sdk-ui-geo.html
@@ -115,7 +115,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoattributeitem.data.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoattributeitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoattributeitem.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoattributeitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.center.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.center.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.colormapping.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.colormapping.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.colorpalette.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.colorpalette.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.colors.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.colors.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.isexportmode.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.isexportmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.legend.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.legend.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.limit.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.points.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.separators.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.separators.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.showlabels.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.showlabels.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.viewport.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.viewport.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfig.zoom.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfig.zoom.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfigviewport.area.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfigviewport.area.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfigviewport.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfigviewport.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeoconfigviewportarea.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeoconfigviewportarea.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodata.color.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodata.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodata.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodata.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodata.location.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodata.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodata.segment.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodata.segment.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodata.size.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodata.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodata.tooltiptext.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodata.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodataitem.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodataitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodataitem.index.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodataitem.index.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeodataitem.name.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeodataitem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.enabled.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.position.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.responsive.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolnglat.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolnglat.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolnglat.lat.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolnglat.lat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolnglat.lng.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolnglat.lng.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolocationitem.data.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolocationitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeolocationitem.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeolocationitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeomeasureitem.data.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeomeasureitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeomeasureitem.format.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeomeasureitem.format.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeomeasureitem.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeomeasureitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.minsize.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopointsconfig.minsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.color.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.config.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.config.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.execconfig.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.location.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.size.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeosegmentitem.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeosegmentitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.igeosegmentitem.uris.html
+++ b/v8.7.0/docs/sdk-ui-geo.igeosegmentitem.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.pushpinsizeoption.html
+++ b/v8.7.0/docs/sdk-ui-geo.pushpinsizeoption.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-geo.zoomchangedcallback.html
+++ b/v8.7.0/docs/sdk-ui-geo.zoomchangedcallback.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.adaptiveloadoptions.html
+++ b/v8.7.0/docs/sdk-ui-loaders.adaptiveloadoptions.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.adaptive.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.adaptive.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.fordashboard.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.fordashboard.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.fromclientworkspace.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.fromclientworkspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.fromworkspace.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.fromworkspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.html
@@ -103,7 +103,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.load.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.load.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.onbackend.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.onbackend.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.staticonly.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.staticonly.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.withbaseprops.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.withbaseprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.withembeddedplugins.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.withembeddedplugins.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloader.withfiltercontext.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloader.withfiltercontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloadresult.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloadresult.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardloadstatus.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardloadstatus.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.dashboardstub.html
+++ b/v8.7.0/docs/sdk-ui-loaders.dashboardstub.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.html
+++ b/v8.7.0/docs/sdk-ui-loaders.html
@@ -126,7 +126,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardbasepropsforloader.dashboard.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardbasepropsforloader.dashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardbasepropsforloader.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardbasepropsforloader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.fordashboard.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.fordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.fromclientworkspace.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.fromclientworkspace.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.fromworkspace.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.fromworkspace.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.load.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.onbackend.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.onbackend.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.withbaseprops.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.withbaseprops.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.withembeddedplugins.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.withembeddedplugins.html
@@ -35,7 +35,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloader.withfiltercontext.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloader.withfiltercontext.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.adaptiveloadoptions.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.adaptiveloadoptions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.clientworkspace.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.clientworkspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.extraplugins.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.extraplugins.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.loadingmode.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardloadoptions.loadingmode.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardstubprops.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardstubprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardstubprops.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardstubprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.idashboardstubprops.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui-loaders.idashboardstubprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.iembeddedplugin.factory.html
+++ b/v8.7.0/docs/sdk-ui-loaders.iembeddedplugin.factory.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.iembeddedplugin.html
+++ b/v8.7.0/docs/sdk-ui-loaders.iembeddedplugin.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.iembeddedplugin.parameters.html
+++ b/v8.7.0/docs/sdk-ui-loaders.iembeddedplugin.parameters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.modulefederationintegration.html
+++ b/v8.7.0/docs/sdk-ui-loaders.modulefederationintegration.html
@@ -116,7 +116,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-loaders.usedashboardloader.html
+++ b/v8.7.0/docs/sdk-ui-loaders.usedashboardloader.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.columnlocator.html
+++ b/v8.7.0/docs/sdk-ui-pivot.columnlocator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.columnresizedcallback.html
+++ b/v8.7.0/docs/sdk-ui-pivot.columnresizedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.columnwidth.html
+++ b/v8.7.0/docs/sdk-ui-pivot.columnwidth.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.columnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.columnwidthitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.defaultcolumnwidth.html
+++ b/v8.7.0/docs/sdk-ui-pivot.defaultcolumnwidth.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.html
+++ b/v8.7.0/docs/sdk-ui-pivot.html
@@ -139,7 +139,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iattributecolumnlocator.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iattributecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iautocolumnwidth.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iautocolumnwidth.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iautocolumnwidth.value.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iautocolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
+++ b/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
+++ b/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
+++ b/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.html
+++ b/v8.7.0/docs/sdk-ui-pivot.icolumnsizing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnlocator.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imenu.aggregations.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imenu.aggregations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imenu.aggregationtypes.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imenu.aggregationtypes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.imenu.html
+++ b/v8.7.0/docs/sdk-ui-pivot.imenu.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.execconfig.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.menu.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.menu.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.separators.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableprops.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ipivottableprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ipivottableprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
+++ b/v8.7.0/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.isattributecolumnlocator.html
+++ b/v8.7.0/docs/sdk-ui-pivot.isattributecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/v8.7.0/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.newattributecolumnlocator.html
+++ b/v8.7.0/docs/sdk-ui-pivot.newattributecolumnlocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
+++ b/v8.7.0/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
+++ b/v8.7.0/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.newwidthforattributecolumn.html
+++ b/v8.7.0/docs/sdk-ui-pivot.newwidthforattributecolumn.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
+++ b/v8.7.0/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.pivottable.html
+++ b/v8.7.0/docs/sdk-ui-pivot.pivottable.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
+++ b/v8.7.0/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.html
@@ -114,7 +114,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.themecontextprovider.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.themecontextprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.thememodifier.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.thememodifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.themeprovider.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.themeprovider.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.usetheme.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.usetheme.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.usethemeisloading.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.usethemeisloading.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-theme-provider.withtheme.html
+++ b/v8.7.0/docs/sdk-ui-theme-provider.withtheme.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
+++ b/v8.7.0/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-vis-commons.html
+++ b/v8.7.0/docs/sdk-ui-vis-commons.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-vis-commons.icolormapping.color.html
+++ b/v8.7.0/docs/sdk-ui-vis-commons.icolormapping.color.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-vis-commons.icolormapping.html
+++ b/v8.7.0/docs/sdk-ui-vis-commons.icolormapping.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui-vis-commons.icolormapping.predicate.html
+++ b/v8.7.0/docs/sdk-ui-vis-commons.icolormapping.predicate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.anyarrayof.html
+++ b/v8.7.0/docs/sdk-ui.anyarrayof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.anymeasure.html
+++ b/v8.7.0/docs/sdk-ui.anymeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.anyplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.anyplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.anyplaceholderof.html
+++ b/v8.7.0/docs/sdk-ui.anyplaceholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.arrayof.html
+++ b/v8.7.0/docs/sdk-ui.arrayof.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributefilterorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.attributefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributefiltersorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.attributefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributeitemnamematch.html
+++ b/v8.7.0/docs/sdk-ui.attributeitemnamematch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributemeasureorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.attributemeasureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributeorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.attributeorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributesmeasuresorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.attributesmeasuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.attributesorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.attributesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.backendprovider.html
+++ b/v8.7.0/docs/sdk-ui.backendprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.badrequestsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.badrequestsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.badrequestsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.badrequestsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cancelledsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.cancelledsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cancelledsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.cancelledsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.attribute.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.attribute.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.attributedisplayform.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.attributedisplayform.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.attributes.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.attributes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.attributetags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.attributetags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedataset.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedataset.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetattribute.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetattribute.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedatasets.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.datedatasettags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.datedatasettags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.html
@@ -122,7 +122,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.measure.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.measure.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.measures.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.measuretags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.measuretags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.visualization.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.visualization.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.visualizations.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.cataloghelper.visualizationtags.html
+++ b/v8.7.0/docs/sdk-ui.cataloghelper.visualizationtags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.chartelementtype.html
+++ b/v8.7.0/docs/sdk-ui.chartelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.charttype.html
+++ b/v8.7.0/docs/sdk-ui.charttype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.composedfromidentifier.html
+++ b/v8.7.0/docs/sdk-ui.composedfromidentifier.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.composedfromuri.html
+++ b/v8.7.0/docs/sdk-ui.composedfromuri.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.composedplaceholderresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui.composedplaceholderresolutioncontext.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.converterror.html
+++ b/v8.7.0/docs/sdk-ui.converterror.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.createnumberjsformatter.html
+++ b/v8.7.0/docs/sdk-ui.createnumberjsformatter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataaccessconfig.html
+++ b/v8.7.0/docs/sdk-ui.dataaccessconfig.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datapoint.html
+++ b/v8.7.0/docs/sdk-ui.datapoint.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datapointcoordinates.html
+++ b/v8.7.0/docs/sdk-ui.datapointcoordinates.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataseriesdescriptor.html
+++ b/v8.7.0/docs/sdk-ui.dataseriesdescriptor.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataseriesdescriptormethods.html
+++ b/v8.7.0/docs/sdk-ui.dataseriesdescriptormethods.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataseriesheaders.html
+++ b/v8.7.0/docs/sdk-ui.dataseriesheaders.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataseriesid.html
+++ b/v8.7.0/docs/sdk-ui.dataseriesid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataslicedescriptor.html
+++ b/v8.7.0/docs/sdk-ui.dataslicedescriptor.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataslicedescriptormethods.html
+++ b/v8.7.0/docs/sdk-ui.dataslicedescriptormethods.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datasliceheaders.html
+++ b/v8.7.0/docs/sdk-ui.datasliceheaders.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datasliceid.html
+++ b/v8.7.0/docs/sdk-ui.datasliceid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datatoolargetocomputesdkerror.html
+++ b/v8.7.0/docs/sdk-ui.datatoolargetocomputesdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.datatoolargetodisplaysdkerror.html
+++ b/v8.7.0/docs/sdk-ui.datatoolargetodisplaysdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.data.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.data.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.dataview.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.definition.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.definition.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.fingerprint.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.fingerprint.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.for.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.for.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.forresult.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.forresult.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.html
@@ -111,7 +111,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.result.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.result.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewfacade.warnings.html
+++ b/v8.7.0/docs/sdk-ui.dataviewfacade.warnings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.dataviewwindow.html
+++ b/v8.7.0/docs/sdk-ui.dataviewwindow.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.defaultcolorpalette.html
+++ b/v8.7.0/docs/sdk-ui.defaultcolorpalette.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.defaultdataaccessconfig.html
+++ b/v8.7.0/docs/sdk-ui.defaultdataaccessconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.defaulterrorhandler.html
+++ b/v8.7.0/docs/sdk-ui.defaulterrorhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.defaultlocale.html
+++ b/v8.7.0/docs/sdk-ui.defaultlocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.drilleventintersectionelementheader.html
+++ b/v8.7.0/docs/sdk-ui.drilleventintersectionelementheader.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.errorcodes.html
+++ b/v8.7.0/docs/sdk-ui.errorcodes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.errorcomponent.defaultprops.html
+++ b/v8.7.0/docs/sdk-ui.errorcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.errorcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.errorcomponent.render.html
+++ b/v8.7.0/docs/sdk-ui.errorcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.execute.html
+++ b/v8.7.0/docs/sdk-ui.execute.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.executeinsight.html
+++ b/v8.7.0/docs/sdk-ui.executeinsight.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.explicitdrill.html
+++ b/v8.7.0/docs/sdk-ui.explicitdrill.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.filterormultivalueplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.filterormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.filterorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.filterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.filtersorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.filtersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.flatten.html
+++ b/v8.7.0/docs/sdk-ui.flatten.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.geolocationmissingsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.geolocationmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.geotokenmissingsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.geotokenmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror.cause.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror.getcause.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror.getcause.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror.getmessage.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror.getmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror.html
@@ -106,7 +106,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.gooddatasdkerror.setype.html
+++ b/v8.7.0/docs/sdk-ui.gooddatasdkerror.setype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.headerpredicates.html
+++ b/v8.7.0/docs/sdk-ui.headerpredicates.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.headertranslator.html
+++ b/v8.7.0/docs/sdk-ui.headertranslator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.headlineelementtype.html
+++ b/v8.7.0/docs/sdk-ui.headlineelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.headlinetype.html
+++ b/v8.7.0/docs/sdk-ui.headlinetype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.html
+++ b/v8.7.0/docs/sdk-ui.html
@@ -341,7 +341,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iattritem.defaultdisplayform.html
+++ b/v8.7.0/docs/sdk-ui.iattritem.defaultdisplayform.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iattritem.displayforms.html
+++ b/v8.7.0/docs/sdk-ui.iattritem.displayforms.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iattritem.html
+++ b/v8.7.0/docs/sdk-ui.iattritem.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iattritem.identifier.html
+++ b/v8.7.0/docs/sdk-ui.iattritem.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iattritem.tags.html
+++ b/v8.7.0/docs/sdk-ui.iattritem.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iattrs.html
+++ b/v8.7.0/docs/sdk-ui.iattrs.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ibackendproviderprops.backend.html
+++ b/v8.7.0/docs/sdk-ui.ibackendproviderprops.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ibackendproviderprops.html
+++ b/v8.7.0/docs/sdk-ui.ibackendproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icatalog.attributes.html
+++ b/v8.7.0/docs/sdk-ui.icatalog.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icatalog.datedatasets.html
+++ b/v8.7.0/docs/sdk-ui.icatalog.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icatalog.html
+++ b/v8.7.0/docs/sdk-ui.icatalog.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icatalog.measures.html
+++ b/v8.7.0/docs/sdk-ui.icatalog.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icatalog.visualizations.html
+++ b/v8.7.0/docs/sdk-ui.icatalog.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icomposedplaceholder.computevalue.html
+++ b/v8.7.0/docs/sdk-ui.icomposedplaceholder.computevalue.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icomposedplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.icomposedplaceholder.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icomposedplaceholder.placeholders.html
+++ b/v8.7.0/docs/sdk-ui.icomposedplaceholder.placeholders.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icomposedplaceholder.type.html
+++ b/v8.7.0/docs/sdk-ui.icomposedplaceholder.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.icomposedplaceholder.use.html
+++ b/v8.7.0/docs/sdk-ui.icomposedplaceholder.use.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataaccessmethods.html
+++ b/v8.7.0/docs/sdk-ui.idataaccessmethods.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataaccessmethods.series.html
+++ b/v8.7.0/docs/sdk-ui.idataaccessmethods.series.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataaccessmethods.slices.html
+++ b/v8.7.0/docs/sdk-ui.idataaccessmethods.slices.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseries.datapoints.html
+++ b/v8.7.0/docs/sdk-ui.idataseries.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseries.descriptor.html
+++ b/v8.7.0/docs/sdk-ui.idataseries.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseries.html
+++ b/v8.7.0/docs/sdk-ui.idataseries.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseries.id.html
+++ b/v8.7.0/docs/sdk-ui.idataseries.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseries.rawdata.html
+++ b/v8.7.0/docs/sdk-ui.idataseries.rawdata.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.allformeasure.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.allformeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.count.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.firstformeasure.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.firstformeasure.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.frommeasures.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.frommeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.html
@@ -100,7 +100,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.scopingattributes.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.scopingattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataseriescollection.toarray.html
+++ b/v8.7.0/docs/sdk-ui.idataseriescollection.toarray.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataset.attributes.html
+++ b/v8.7.0/docs/sdk-ui.idataset.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataset.html
+++ b/v8.7.0/docs/sdk-ui.idataset.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataset.identifier.html
+++ b/v8.7.0/docs/sdk-ui.idataset.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataset.tags.html
+++ b/v8.7.0/docs/sdk-ui.idataset.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslice.datapoints.html
+++ b/v8.7.0/docs/sdk-ui.idataslice.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslice.descriptor.html
+++ b/v8.7.0/docs/sdk-ui.idataslice.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslice.html
+++ b/v8.7.0/docs/sdk-ui.idataslice.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslice.id.html
+++ b/v8.7.0/docs/sdk-ui.idataslice.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslice.rawdata.html
+++ b/v8.7.0/docs/sdk-ui.idataslice.rawdata.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslicecollection.count.html
+++ b/v8.7.0/docs/sdk-ui.idataslicecollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslicecollection.descriptors.html
+++ b/v8.7.0/docs/sdk-ui.idataslicecollection.descriptors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslicecollection.html
+++ b/v8.7.0/docs/sdk-ui.idataslicecollection.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idataslicecollection.toarray.html
+++ b/v8.7.0/docs/sdk-ui.idataslicecollection.toarray.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idatavisualizationprops.execution.html
+++ b/v8.7.0/docs/sdk-ui.idatavisualizationprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idatavisualizationprops.html
+++ b/v8.7.0/docs/sdk-ui.idatavisualizationprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.identifiermatch.html
+++ b/v8.7.0/docs/sdk-ui.identifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idisplayforms.html
+++ b/v8.7.0/docs/sdk-ui.idisplayforms.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillableitem.html
+++ b/v8.7.0/docs/sdk-ui.idrillableitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillableitemidentifier.html
+++ b/v8.7.0/docs/sdk-ui.idrillableitemidentifier.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillableitemidentifier.identifier.html
+++ b/v8.7.0/docs/sdk-ui.idrillableitemidentifier.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillableitemuri.html
+++ b/v8.7.0/docs/sdk-ui.idrillableitemuri.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillableitemuri.uri.html
+++ b/v8.7.0/docs/sdk-ui.idrillableitemuri.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillconfig.dataview.html
+++ b/v8.7.0/docs/sdk-ui.idrillconfig.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillconfig.html
+++ b/v8.7.0/docs/sdk-ui.idrillconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillconfig.ondrill.html
+++ b/v8.7.0/docs/sdk-ui.idrillconfig.ondrill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillevent.dataview.html
+++ b/v8.7.0/docs/sdk-ui.idrillevent.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillevent.drillcontext.html
+++ b/v8.7.0/docs/sdk-ui.idrillevent.drillcontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillevent.html
+++ b/v8.7.0/docs/sdk-ui.idrillevent.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcallback.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.columnindex.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.element.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.intersection.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.points.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.row.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.rowindex.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.type.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.value.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.x.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.y.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontext.z.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontext.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.element.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.points.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.type.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextgroup.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.element.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.intersection.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.type.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.value.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextheadline.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.element.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.intersection.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.type.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.value.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.x.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.y.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.z.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextpoint.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.columnindex.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.element.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.intersection.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.row.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.rowindex.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontexttable.type.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontexttable.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.element.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.intersection.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.type.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.value.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventcontextxirr.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventintersectionelement.header.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventintersectionelement.header.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrilleventintersectionelement.html
+++ b/v8.7.0/docs/sdk-ui.idrilleventintersectionelement.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillintersectionattributeitem.html
+++ b/v8.7.0/docs/sdk-ui.idrillintersectionattributeitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillpoint.html
+++ b/v8.7.0/docs/sdk-ui.idrillpoint.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillpoint.intersection.html
+++ b/v8.7.0/docs/sdk-ui.idrillpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillpoint.type.html
+++ b/v8.7.0/docs/sdk-ui.idrillpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillpoint.x.html
+++ b/v8.7.0/docs/sdk-ui.idrillpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.idrillpoint.y.html
+++ b/v8.7.0/docs/sdk-ui.idrillpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrordescriptors.html
+++ b/v8.7.0/docs/sdk-ui.ierrordescriptors.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.classname.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.clientheight.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.clientheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.code.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.code.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.description.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.height.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.icon.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.icon.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.message.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.message.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.style.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.style.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ierrorprops.width.html
+++ b/v8.7.0/docs/sdk-ui.ierrorprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteerrorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteerrorcomponent.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteerrorcomponentprops.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteerrorcomponentprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.backend.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.children.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.children.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.componentname.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.dateformat.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.dimensions.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.filters.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.insight.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.insight.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.sorts.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.window.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.window.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteinsightprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteinsightprops.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteloadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteloadingcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.backend.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.children.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.componentname.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.componentname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.errorcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.exporttitle.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.filters.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.loadonmount.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.seriesby.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.seriesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.slicesby.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.slicesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.sortby.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.totals.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.window.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecuteprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui.iexecuteprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.componentname.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.filters.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.seriesby.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.slicesby.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.sortby.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexecutionconfiguration.totals.html
+++ b/v8.7.0/docs/sdk-ui.iexecutionconfiguration.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iexportfunction.html
+++ b/v8.7.0/docs/sdk-ui.iexportfunction.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iextendedexportconfig.html
+++ b/v8.7.0/docs/sdk-ui.iextendedexportconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
+++ b/v8.7.0/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iheaderpredicate.html
+++ b/v8.7.0/docs/sdk-ui.iheaderpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iheaderpredicatecontext.dv.html
+++ b/v8.7.0/docs/sdk-ui.iheaderpredicatecontext.dv.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iheaderpredicatecontext.html
+++ b/v8.7.0/docs/sdk-ui.iheaderpredicatecontext.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ihighchartscategoriestree.html
+++ b/v8.7.0/docs/sdk-ui.ihighchartscategoriestree.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ihighchartscategoriestree.tick.html
+++ b/v8.7.0/docs/sdk-ui.ihighchartscategoriestree.tick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ihighchartsparenttick.html
+++ b/v8.7.0/docs/sdk-ui.ihighchartsparenttick.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ihighchartsparenttick.label.html
+++ b/v8.7.0/docs/sdk-ui.ihighchartsparenttick.label.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ihighchartsparenttick.leaves.html
+++ b/v8.7.0/docs/sdk-ui.ihighchartsparenttick.leaves.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ihighchartsparenttick.startat.html
+++ b/v8.7.0/docs/sdk-ui.ihighchartsparenttick.startat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iidentifierwithtags.html
+++ b/v8.7.0/docs/sdk-ui.iidentifierwithtags.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iidentifierwithtags.identifier.html
+++ b/v8.7.0/docs/sdk-ui.iidentifierwithtags.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iidentifierwithtags.tags.html
+++ b/v8.7.0/docs/sdk-ui.iidentifierwithtags.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.backend.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.filters.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.locale.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.measure.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.separators.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ikpiprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui.ikpiprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.classname.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.color.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.height.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.height.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.imageheight.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.imageheight.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.imagewidth.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.imagewidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.inline.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.inline.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.speed.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.speed.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingprops.width.html
+++ b/v8.7.0/docs/sdk-ui.iloadingprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingstate.html
+++ b/v8.7.0/docs/sdk-ui.iloadingstate.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iloadingstate.isloading.html
+++ b/v8.7.0/docs/sdk-ui.iloadingstate.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ilocale.html
+++ b/v8.7.0/docs/sdk-ui.ilocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.imappingheader.html
+++ b/v8.7.0/docs/sdk-ui.imappingheader.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholderoptions.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholderoptions.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholderoptions.id.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholderoptions.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholderoptions.validate.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholderoptions.validate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholdersproviderprops.children.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholdersproviderprops.children.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholdersproviderprops.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholdersproviderprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
+++ b/v8.7.0/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.children.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.execution.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.exporttitle.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.loadonmount.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.irawexecuteprops.window.html
+++ b/v8.7.0/docs/sdk-ui.irawexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isanyplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.isanyplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isbadrequest.html
+++ b/v8.7.0/docs/sdk-ui.isbadrequest.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iscancelledsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.iscancelledsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iscomposedplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.iscomposedplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isdatatoolargetocompute.html
+++ b/v8.7.0/docs/sdk-ui.isdatatoolargetocompute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isdatatoolargetodisplay.html
+++ b/v8.7.0/docs/sdk-ui.isdatatoolargetodisplay.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isdrillableitem.html
+++ b/v8.7.0/docs/sdk-ui.isdrillableitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isdrillableitemidentifier.html
+++ b/v8.7.0/docs/sdk-ui.isdrillableitemidentifier.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isdrillableitemuri.html
+++ b/v8.7.0/docs/sdk-ui.isdrillableitemuri.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isdrillintersectionattributeitem.html
+++ b/v8.7.0/docs/sdk-ui.isdrillintersectionattributeitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isexplicitdrill.html
+++ b/v8.7.0/docs/sdk-ui.isexplicitdrill.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isgeolocationmissing.html
+++ b/v8.7.0/docs/sdk-ui.isgeolocationmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isgeotokenmissing.html
+++ b/v8.7.0/docs/sdk-ui.isgeotokenmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isgooddatasdkerror.html
+++ b/v8.7.0/docs/sdk-ui.isgooddatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isheaderpredicate.html
+++ b/v8.7.0/docs/sdk-ui.isheaderpredicate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isnegativevalues.html
+++ b/v8.7.0/docs/sdk-ui.isnegativevalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isnodatasdkerror.html
+++ b/v8.7.0/docs/sdk-ui.isnodatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isnotfound.html
+++ b/v8.7.0/docs/sdk-ui.isnotfound.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.isplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isprotectedreport.html
+++ b/v8.7.0/docs/sdk-ui.isprotectedreport.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isunauthorized.html
+++ b/v8.7.0/docs/sdk-ui.isunauthorized.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.isunknownsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.isunknownsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationcontextproviderprops.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationcontextproviderprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translations.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translations.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translationscustomizationisloading.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translationscustomizationisloading.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.backend.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.customize.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.customize.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.render.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.render.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.translations.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.translations.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui.itranslationscustomizationproviderprops.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iusecomposedplaceholderhook.html
+++ b/v8.7.0/docs/sdk-ui.iusecomposedplaceholderhook.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.backend.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.componentname.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.filters.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.seriesby.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.slicesby.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.sortby.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.totals.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutionconfig.workspace.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutionconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
+++ b/v8.7.0/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.window.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
+++ b/v8.7.0/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iusepagedresourceresult.html
+++ b/v8.7.0/docs/sdk-ui.iusepagedresourceresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iusepagedresourceresult.isloading.html
+++ b/v8.7.0/docs/sdk-ui.iusepagedresourceresult.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iusepagedresourcestate.html
+++ b/v8.7.0/docs/sdk-ui.iusepagedresourcestate.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iusepagedresourcestate.items.html
+++ b/v8.7.0/docs/sdk-ui.iusepagedresourcestate.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
+++ b/v8.7.0/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iuseplaceholderhook.html
+++ b/v8.7.0/docs/sdk-ui.iuseplaceholderhook.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.onerror.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationprops.drillableitems.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationprops.drillableitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationprops.errorcomponent.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationprops.exporttitle.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationprops.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.ivisualizationprops.locale.html
+++ b/v8.7.0/docs/sdk-ui.ivisualizationprops.locale.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iwithloadingevents.html
+++ b/v8.7.0/docs/sdk-ui.iwithloadingevents.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iwithloadingevents.onerror.html
+++ b/v8.7.0/docs/sdk-ui.iwithloadingevents.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iwithloadingevents.onexportready.html
+++ b/v8.7.0/docs/sdk-ui.iwithloadingevents.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
+++ b/v8.7.0/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
+++ b/v8.7.0/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iwithloadingevents.onloadingstart.html
+++ b/v8.7.0/docs/sdk-ui.iwithloadingevents.onloadingstart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iworkspaceproviderprops.html
+++ b/v8.7.0/docs/sdk-ui.iworkspaceproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.iworkspaceproviderprops.workspace.html
+++ b/v8.7.0/docs/sdk-ui.iworkspaceproviderprops.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.kpi.html
+++ b/v8.7.0/docs/sdk-ui.kpi.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.loadingcomponent.defaultprops.html
+++ b/v8.7.0/docs/sdk-ui.loadingcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.loadingcomponent.html
+++ b/v8.7.0/docs/sdk-ui.loadingcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.loadingcomponent.render.html
+++ b/v8.7.0/docs/sdk-ui.loadingcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.localidentifiermatch.html
+++ b/v8.7.0/docs/sdk-ui.localidentifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.measureof.html
+++ b/v8.7.0/docs/sdk-ui.measureof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.measureorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.measureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.measuresorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.measuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.negativevaluessdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.negativevaluessdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.negativevaluessdkerror.html
+++ b/v8.7.0/docs/sdk-ui.negativevaluessdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.newcomposedplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.newcomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.newerrormapping.html
+++ b/v8.7.0/docs/sdk-ui.newerrormapping.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.newplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.newplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.nodatasdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.nodatasdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.nodatasdkerror.html
+++ b/v8.7.0/docs/sdk-ui.nodatasdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.notfoundsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.notfoundsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.notfoundsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.notfoundsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.nullablefilterorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.nullablefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.nullablefiltersorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.nullablefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.onerror.html
+++ b/v8.7.0/docs/sdk-ui.onerror.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.onexportready.html
+++ b/v8.7.0/docs/sdk-ui.onexportready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.onfireddrillevent.html
+++ b/v8.7.0/docs/sdk-ui.onfireddrillevent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.onloadingchanged.html
+++ b/v8.7.0/docs/sdk-ui.onloadingchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.pickcorrectinsightwording.html
+++ b/v8.7.0/docs/sdk-ui.pickcorrectinsightwording.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.placeholderof.html
+++ b/v8.7.0/docs/sdk-ui.placeholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.placeholderresolvedvalue.html
+++ b/v8.7.0/docs/sdk-ui.placeholderresolvedvalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.placeholdersprovider.html
+++ b/v8.7.0/docs/sdk-ui.placeholdersprovider.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.placeholdersresolvedvalues.html
+++ b/v8.7.0/docs/sdk-ui.placeholdersresolvedvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.placeholdersvalues.html
+++ b/v8.7.0/docs/sdk-ui.placeholdersvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.placeholdervalue.html
+++ b/v8.7.0/docs/sdk-ui.placeholdervalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.protectedreportsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.protectedreportsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.protectedreportsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.protectedreportsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.rawexecute.html
+++ b/v8.7.0/docs/sdk-ui.rawexecute.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.removeallinsighttoreporttranslations.html
+++ b/v8.7.0/docs/sdk-ui.removeallinsighttoreporttranslations.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.resolveusecancelablepromiseserror.html
+++ b/v8.7.0/docs/sdk-ui.resolveusecancelablepromiseserror.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.resolveusecancelablepromisesstatus.html
+++ b/v8.7.0/docs/sdk-ui.resolveusecancelablepromisesstatus.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.sdkerrortype.html
+++ b/v8.7.0/docs/sdk-ui.sdkerrortype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.sortsorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.sortsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.tableelementtype.html
+++ b/v8.7.0/docs/sdk-ui.tableelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.tabletype.html
+++ b/v8.7.0/docs/sdk-ui.tabletype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.totalsorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.totalsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.translationscustomizationcontextprovider.html
+++ b/v8.7.0/docs/sdk-ui.translationscustomizationcontextprovider.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.translationscustomizationprovider.html
+++ b/v8.7.0/docs/sdk-ui.translationscustomizationprovider.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
+++ b/v8.7.0/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.unauthorizedsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.unauthorizedsdkerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.unexpectedsdkerror._constructor_.html
+++ b/v8.7.0/docs/sdk-ui.unexpectedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.unexpectedsdkerror.html
+++ b/v8.7.0/docs/sdk-ui.unexpectedsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.uniontointersection.html
+++ b/v8.7.0/docs/sdk-ui.uniontointersection.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.urimatch.html
+++ b/v8.7.0/docs/sdk-ui.urimatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usebackend.html
+++ b/v8.7.0/docs/sdk-ui.usebackend.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usebackendstrict.html
+++ b/v8.7.0/docs/sdk-ui.usebackendstrict.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromise.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromise.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromisecallbacks.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromisecallbacks.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromiseerrorstate.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromiseerrorstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromiseloadingstate.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromiseloadingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromiseoptions.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromiseoptions.html
@@ -81,7 +81,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromisependingstate.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromisependingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromisestate.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromisestate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromisestatus.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromisestatus.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecancelablepromisesuccessstate.html
+++ b/v8.7.0/docs/sdk-ui.usecancelablepromisesuccessstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usecomposedplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.usecomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usedataexport.html
+++ b/v8.7.0/docs/sdk-ui.usedataexport.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usedataexportcallbacks.html
+++ b/v8.7.0/docs/sdk-ui.usedataexportcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usedataexportstate.html
+++ b/v8.7.0/docs/sdk-ui.usedataexportstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usedataview.html
+++ b/v8.7.0/docs/sdk-ui.usedataview.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usedataviewcallbacks.html
+++ b/v8.7.0/docs/sdk-ui.usedataviewcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usedataviewstate.html
+++ b/v8.7.0/docs/sdk-ui.usedataviewstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useexecution.html
+++ b/v8.7.0/docs/sdk-ui.useexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useexecutiondataview.html
+++ b/v8.7.0/docs/sdk-ui.useexecutiondataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useinsightdataview.html
+++ b/v8.7.0/docs/sdk-ui.useinsightdataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.usepagedresource.html
+++ b/v8.7.0/docs/sdk-ui.usepagedresource.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.useplaceholder.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.useplaceholders.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useresolvevalueswithplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.useresolvevalueswithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useresolvevaluewithplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.useresolvevaluewithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useworkspace.html
+++ b/v8.7.0/docs/sdk-ui.useworkspace.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.useworkspacestrict.html
+++ b/v8.7.0/docs/sdk-ui.useworkspacestrict.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.valueformatter.html
+++ b/v8.7.0/docs/sdk-ui.valueformatter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.valueormultivalueplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.valueormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.valueorplaceholder.html
+++ b/v8.7.0/docs/sdk-ui.valueorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.valuesorplaceholders.html
+++ b/v8.7.0/docs/sdk-ui.valuesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.viselementtype.html
+++ b/v8.7.0/docs/sdk-ui.viselementtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.vistype.html
+++ b/v8.7.0/docs/sdk-ui.vistype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.withloadingresult.html
+++ b/v8.7.0/docs/sdk-ui.withloadingresult.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.withtranslationscustomization.html
+++ b/v8.7.0/docs/sdk-ui.withtranslationscustomization.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.workspaceprovider.html
+++ b/v8.7.0/docs/sdk-ui.workspaceprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/docs/sdk-ui.xirrtype.html
+++ b/v8.7.0/docs/sdk-ui.xirrtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/en/help.html
+++ b/v8.7.0/en/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/en/index.html
+++ b/v8.7.0/en/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/en/users.html
+++ b/v8.7.0/en/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/help.html
+++ b/v8.7.0/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/index.html
+++ b/v8.7.0/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/v8.7.0/users.html
+++ b/v8.7.0/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:8.7.0","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/index.html
+++ b/vNext/docs/index.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.analyticalbackenderror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
+++ b/vNext/docs/sdk-backend-spi.analyticalbackenderror.abetype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.analyticalbackenderror.cause.html
+++ b/vNext/docs/sdk-backend-spi.analyticalbackenderror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.analyticalbackenderror.html
+++ b/vNext/docs/sdk-backend-spi.analyticalbackenderror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.analyticalbackenderrortypes.html
+++ b/vNext/docs/sdk-backend-spi.analyticalbackenderrortypes.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.analyticalbackendfactory.html
+++ b/vNext/docs/sdk-backend-spi.analyticalbackendfactory.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.attributedescriptorlocalid.html
+++ b/vNext/docs/sdk-backend-spi.attributedescriptorlocalid.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.attributedescriptorname.html
+++ b/vNext/docs/sdk-backend-spi.attributedescriptorname.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.authenticationflow.html
+++ b/vNext/docs/sdk-backend-spi.authenticationflow.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.catalogitem.html
+++ b/vNext/docs/sdk-backend-spi.catalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.catalogitemmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.catalogitemmetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.catalogitemtype.html
+++ b/vNext/docs/sdk-backend-spi.catalogitemtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.datacolumntype.html
+++ b/vNext/docs/sdk-backend-spi.datacolumntype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.datasetloadstatus.html
+++ b/vNext/docs/sdk-backend-spi.datasetloadstatus.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.datatoolargeerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.datatoolargeerror.html
+++ b/vNext/docs/sdk-backend-spi.datatoolargeerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.datavalue.html
+++ b/vNext/docs/sdk-backend-spi.datavalue.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.errorconverter.html
+++ b/vNext/docs/sdk-backend-spi.errorconverter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.filterwithresolvableelements.html
+++ b/vNext/docs/sdk-backend-spi.filterwithresolvableelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.groupablecatalogitem.html
+++ b/vNext/docs/sdk-backend-spi.groupablecatalogitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.html
+++ b/vNext/docs/sdk-backend-spi.html
@@ -299,7 +299,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iaccessgrantee.html
+++ b/vNext/docs/sdk-backend-spi.iaccessgrantee.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.authenticate.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.capabilities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.config.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.currentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.deauthenticate.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.isauthenticated.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.onhostname.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.organization.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.organization.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.organizations.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.withauthentication.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.withtelemetry.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.workspace.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackend.workspaces.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackendconfig.hostname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalbackendconfig.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalbackendconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.accesscontrol.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.accesscontrol.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.attributes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.catalog.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.dashboards.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.datasets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.datefilterconfigs.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.execution.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.facts.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.getparentworkspace.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.html
@@ -109,7 +109,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.insights.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.permissions.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.settings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.styling.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.usergroups.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.usergroups.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.users.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.users.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
+++ b/vNext/docs/sdk-backend-spi.ianalyticalworkspace.workspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
+++ b/vNext/docs/sdk-backend-spi.iattributedescriptor.attributeheader.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedescriptor.html
+++ b/vNext/docs/sdk-backend-spi.iattributedescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
+++ b/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
+++ b/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.displayformtype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
+++ b/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.isdefault.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
+++ b/vNext/docs/sdk-backend-spi.iattributedisplayformmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelement.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelement.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelement.title.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelement.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelement.uri.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelement.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.deleted.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
+++ b/vNext/docs/sdk-backend-spi.iattributeelementexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
+++ b/vNext/docs/sdk-backend-spi.iattributemetadataobject.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
+++ b/vNext/docs/sdk-backend-spi.iattributemetadataobject.drilldownstep.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributemetadataobject.drilltoattributelink.html
+++ b/vNext/docs/sdk-backend-spi.iattributemetadataobject.drilltoattributelink.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributemetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.iattributemetadataobject.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iattributemetadataobject.type.html
+++ b/vNext/docs/sdk-backend-spi.iattributemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticatedprincipal.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticatedprincipal.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticatedprincipal.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticatedprincipal.usermeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationcontext.backend.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationcontext.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationcontext.client.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationcontext.client.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationcontext.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationcontext.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationprovider.authenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationprovider.deauthenticate.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationprovider.getcurrentprincipal.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationprovider.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationprovider.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationprovider.initializeclient.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
+++ b/vNext/docs/sdk-backend-spi.iauthenticationprovider.onnotauthenticated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.allowsinconsistentrelations.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.allowsinconsistentrelations.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculategrandtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculatenativetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculatesubtotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.cancalculatetotals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.canexecutebyreference.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.canexportcsv.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.canexportxlsx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.cansortdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.cantransformexistingresult.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.hastypescopedidentifiers.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.hastypescopedidentifiers.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.html
@@ -109,7 +109,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.maxdimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsaccesscontrol.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsaccesscontrol.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportscsvuploader.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportselementsqueryparentfiltering.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportselementuris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsexplain.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsexplain.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsgenericdateattributeelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportshyperlinkattributelabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportskpiwidget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsobjecturis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsowners.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsowners.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportsrankingfilterwithmeasurevaluefilter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportswidgetentity.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.supportswidgetentity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibackendcapabilities.usesstrictaccesscontrol.html
+++ b/vNext/docs/sdk-backend-spi.ibackendcapabilities.usesstrictaccesscontrol.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibracketexpressiontoken.html
+++ b/vNext/docs/sdk-backend-spi.ibracketexpressiontoken.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibracketexpressiontoken.type.html
+++ b/vNext/docs/sdk-backend-spi.ibracketexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ibracketexpressiontoken.value.html
+++ b/vNext/docs/sdk-backend-spi.ibracketexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogattribute.attribute.html
+++ b/vNext/docs/sdk-backend-spi.icatalogattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
+++ b/vNext/docs/sdk-backend-spi.icatalogattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogattribute.displayforms.html
+++ b/vNext/docs/sdk-backend-spi.icatalogattribute.displayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
+++ b/vNext/docs/sdk-backend-spi.icatalogattribute.geopindisplayforms.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogattribute.html
+++ b/vNext/docs/sdk-backend-spi.icatalogattribute.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogattribute.type.html
+++ b/vNext/docs/sdk-backend-spi.icatalogattribute.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdateattribute.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdateattribute.defaultdisplayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdateattribute.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdateattribute.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdateattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdatedataset.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdatedataset.dateattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdatedataset.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdatedataset.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdatedataset.relevance.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogdatedataset.type.html
+++ b/vNext/docs/sdk-backend-spi.icatalogdatedataset.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogfact.fact.html
+++ b/vNext/docs/sdk-backend-spi.icatalogfact.fact.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogfact.html
+++ b/vNext/docs/sdk-backend-spi.icatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogfact.type.html
+++ b/vNext/docs/sdk-backend-spi.icatalogfact.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icataloggroup.html
+++ b/vNext/docs/sdk-backend-spi.icataloggroup.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icataloggroup.tag.html
+++ b/vNext/docs/sdk-backend-spi.icataloggroup.tag.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icataloggroup.title.html
+++ b/vNext/docs/sdk-backend-spi.icataloggroup.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogitembase.html
+++ b/vNext/docs/sdk-backend-spi.icatalogitembase.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogitembase.type.html
+++ b/vNext/docs/sdk-backend-spi.icatalogitembase.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogmeasure.html
+++ b/vNext/docs/sdk-backend-spi.icatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogmeasure.measure.html
+++ b/vNext/docs/sdk-backend-spi.icatalogmeasure.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icatalogmeasure.type.html
+++ b/vNext/docs/sdk-backend-spi.icatalogmeasure.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icommentexpressiontoken.html
+++ b/vNext/docs/sdk-backend-spi.icommentexpressiontoken.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icommentexpressiontoken.type.html
+++ b/vNext/docs/sdk-backend-spi.icommentexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.icommentexpressiontoken.value.html
+++ b/vNext/docs/sdk-backend-spi.icommentexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idashboardmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.idashboardmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idashboardmetadataobject.type.html
+++ b/vNext/docs/sdk-backend-spi.idashboardmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatacolumn.column.html
+++ b/vNext/docs/sdk-backend-spi.idatacolumn.column.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatacolumn.html
+++ b/vNext/docs/sdk-backend-spi.idatacolumn.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataheader.columns.html
+++ b/vNext/docs/sdk-backend-spi.idataheader.columns.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataheader.headerrowindex.html
+++ b/vNext/docs/sdk-backend-spi.idataheader.headerrowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataheader.html
+++ b/vNext/docs/sdk-backend-spi.idataheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataset.dataset.html
+++ b/vNext/docs/sdk-backend-spi.idataset.dataset.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataset.html
+++ b/vNext/docs/sdk-backend-spi.idataset.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetloadinfo.created.html
+++ b/vNext/docs/sdk-backend-spi.idatasetloadinfo.created.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetloadinfo.html
+++ b/vNext/docs/sdk-backend-spi.idatasetloadinfo.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetloadinfo.owner.html
+++ b/vNext/docs/sdk-backend-spi.idatasetloadinfo.owner.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetloadinfo.status.html
+++ b/vNext/docs/sdk-backend-spi.idatasetloadinfo.status.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.idatasetmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetmetadataobject.type.html
+++ b/vNext/docs/sdk-backend-spi.idatasetmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetuser.fullname.html
+++ b/vNext/docs/sdk-backend-spi.idatasetuser.fullname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetuser.html
+++ b/vNext/docs/sdk-backend-spi.idatasetuser.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatasetuser.login.html
+++ b/vNext/docs/sdk-backend-spi.idatasetuser.login.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.count.html
+++ b/vNext/docs/sdk-backend-spi.idataview.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.data.html
+++ b/vNext/docs/sdk-backend-spi.idataview.data.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.definition.html
+++ b/vNext/docs/sdk-backend-spi.idataview.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.equals.html
+++ b/vNext/docs/sdk-backend-spi.idataview.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.fingerprint.html
+++ b/vNext/docs/sdk-backend-spi.idataview.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.headeritems.html
+++ b/vNext/docs/sdk-backend-spi.idataview.headeritems.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.html
+++ b/vNext/docs/sdk-backend-spi.idataview.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.offset.html
+++ b/vNext/docs/sdk-backend-spi.idataview.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.result.html
+++ b/vNext/docs/sdk-backend-spi.idataview.result.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.totalcount.html
+++ b/vNext/docs/sdk-backend-spi.idataview.totalcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.totals.html
+++ b/vNext/docs/sdk-backend-spi.idataview.totals.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idataview.warnings.html
+++ b/vNext/docs/sdk-backend-spi.idataview.warnings.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
+++ b/vNext/docs/sdk-backend-spi.idatefilterconfigsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idimensiondescriptor.headers.html
+++ b/vNext/docs/sdk-backend-spi.idimensiondescriptor.headers.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idimensiondescriptor.html
+++ b/vNext/docs/sdk-backend-spi.idimensiondescriptor.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.idimensionitemdescriptor.html
+++ b/vNext/docs/sdk-backend-spi.idimensionitemdescriptor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.query.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.withattributefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.withdatefilters.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.withdatefilters.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.withlimit.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.withmeasures.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.withmeasures.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.withoffset.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsquery.withoptions.html
+++ b/vNext/docs/sdk-backend-spi.ielementsquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryattributefilter.attributefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryattributefilter.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryattributefilter.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryattributefilter.overattribute.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryfactory.fordisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryfactory.forfilter.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryfactory.forfilter.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryfactory.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.complement.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.includetotalcountwithoutfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.order.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.order.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.prompt.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryoptions.uris.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ielementsqueryresult.html
+++ b/vNext/docs/sdk-backend-spi.ielementsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionfactory.forbuckets.html
@@ -36,7 +36,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionfactory.fordefinition.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionfactory.forinsight.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionfactory.forinsightbyref.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionfactory.foritems.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionfactory.foritems.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionfactory.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionfactory.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.definition.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.dimensions.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.dimensions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.equals.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.export.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.export.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.fingerprint.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.readall.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.readall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.readwindow.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.readwindow.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexecutionresult.transform.html
+++ b/vNext/docs/sdk-backend-spi.iexecutionresult.transform.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportconfig.format.html
+++ b/vNext/docs/sdk-backend-spi.iexportconfig.format.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportconfig.html
+++ b/vNext/docs/sdk-backend-spi.iexportconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
+++ b/vNext/docs/sdk-backend-spi.iexportconfig.mergeheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportconfig.showfilters.html
+++ b/vNext/docs/sdk-backend-spi.iexportconfig.showfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportconfig.title.html
+++ b/vNext/docs/sdk-backend-spi.iexportconfig.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportresult.html
+++ b/vNext/docs/sdk-backend-spi.iexportresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iexportresult.uri.html
+++ b/vNext/docs/sdk-backend-spi.iexportresult.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ifactmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.ifactmetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ifactmetadataobject.type.html
+++ b/vNext/docs/sdk-backend-spi.ifactmetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ifilterelementsquery.html
+++ b/vNext/docs/sdk-backend-spi.ifilterelementsquery.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ifilterelementsquery.query.html
+++ b/vNext/docs/sdk-backend-spi.ifilterelementsquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ifilterelementsquery.withlimit.html
+++ b/vNext/docs/sdk-backend-spi.ifilterelementsquery.withlimit.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ifilterelementsquery.withoffset.html
+++ b/vNext/docs/sdk-backend-spi.ifilterelementsquery.withoffset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.igetinsightoptions.html
+++ b/vNext/docs/sdk-backend-spi.igetinsightoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.igetinsightoptions.loaduserdata.html
+++ b/vNext/docs/sdk-backend-spi.igetinsightoptions.loaduserdata.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
+++ b/vNext/docs/sdk-backend-spi.igetvisualizationclassesoptions.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
+++ b/vNext/docs/sdk-backend-spi.igetvisualizationclassesoptions.includedeprecated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
+++ b/vNext/docs/sdk-backend-spi.igroupablecatalogitembase.groups.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.igroupablecatalogitembase.html
+++ b/vNext/docs/sdk-backend-spi.igroupablecatalogitembase.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
+++ b/vNext/docs/sdk-backend-spi.iinsightreferences.catalogitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
+++ b/vNext/docs/sdk-backend-spi.iinsightreferences.datasetmeta.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightreferences.html
+++ b/vNext/docs/sdk-backend-spi.iinsightreferences.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
+++ b/vNext/docs/sdk-backend-spi.iinsightreferencing.analyticaldashboards.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightreferencing.html
+++ b/vNext/docs/sdk-backend-spi.iinsightreferencing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.author.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.loaduserdata.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.loaduserdata.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.orderby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryoptions.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iinsightsqueryresult.html
+++ b/vNext/docs/sdk-backend-spi.iinsightsqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasuredescriptor.html
+++ b/vNext/docs/sdk-backend-spi.imeasuredescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
+++ b/vNext/docs/sdk-backend-spi.imeasuredescriptor.measureheaderitem.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasureexpressiontoken.html
+++ b/vNext/docs/sdk-backend-spi.imeasureexpressiontoken.html
@@ -106,7 +106,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasuregroupdescriptor.html
+++ b/vNext/docs/sdk-backend-spi.imeasuregroupdescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
+++ b/vNext/docs/sdk-backend-spi.imeasuregroupdescriptor.measuregroupheader.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasuremetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.imeasuremetadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
+++ b/vNext/docs/sdk-backend-spi.imeasuremetadataobjectdefinition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasurereferencing.html
+++ b/vNext/docs/sdk-backend-spi.imeasurereferencing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasurereferencing.insights.html
+++ b/vNext/docs/sdk-backend-spi.imeasurereferencing.insights.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imeasurereferencing.measures.html
+++ b/vNext/docs/sdk-backend-spi.imeasurereferencing.measures.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.imetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.imetadataobject.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.insightordering.html
+++ b/vNext/docs/sdk-backend-spi.insightordering.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.insightreferencetypes.html
+++ b/vNext/docs/sdk-backend-spi.insightreferencetypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.html
+++ b/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.id.html
+++ b/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
+++ b/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
+++ b/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
+++ b/vNext/docs/sdk-backend-spi.iobjectexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganization.getdescriptor.html
+++ b/vNext/docs/sdk-backend-spi.iorganization.getdescriptor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganization.html
+++ b/vNext/docs/sdk-backend-spi.iorganization.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganization.organizationid.html
+++ b/vNext/docs/sdk-backend-spi.iorganization.organizationid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganization.securitysettings.html
+++ b/vNext/docs/sdk-backend-spi.iorganization.securitysettings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganizationdescriptor.html
+++ b/vNext/docs/sdk-backend-spi.iorganizationdescriptor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganizationdescriptor.id.html
+++ b/vNext/docs/sdk-backend-spi.iorganizationdescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganizationdescriptor.title.html
+++ b/vNext/docs/sdk-backend-spi.iorganizationdescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
+++ b/vNext/docs/sdk-backend-spi.iorganizations.getcurrentorganization.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iorganizations.html
+++ b/vNext/docs/sdk-backend-spi.iorganizations.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.all.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.all.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.allsorted.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.allsorted.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.goto.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.goto.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.items.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.limit.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.next.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.next.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.offset.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.offset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipagedresource.totalcount.html
+++ b/vNext/docs/sdk-backend-spi.ipagedresource.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.definition.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.definition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.equals.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.equals.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.execute.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.execute.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.fingerprint.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.withdateformat.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.withdimensions.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.withexecconfig.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
+++ b/vNext/docs/sdk-backend-spi.ipreparedexecution.withsorting.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
+++ b/vNext/docs/sdk-backend-spi.iresultattributeheader.attributeheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultattributeheader.html
+++ b/vNext/docs/sdk-backend-spi.iresultattributeheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultheader.html
+++ b/vNext/docs/sdk-backend-spi.iresultheader.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultmeasureheader.html
+++ b/vNext/docs/sdk-backend-spi.iresultmeasureheader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
+++ b/vNext/docs/sdk-backend-spi.iresultmeasureheader.measureheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresulttotalheader.html
+++ b/vNext/docs/sdk-backend-spi.iresulttotalheader.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
+++ b/vNext/docs/sdk-backend-spi.iresulttotalheader.totalheaderitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultwarning.html
+++ b/vNext/docs/sdk-backend-spi.iresultwarning.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultwarning.message.html
+++ b/vNext/docs/sdk-backend-spi.iresultwarning.message.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultwarning.parameters.html
+++ b/vNext/docs/sdk-backend-spi.iresultwarning.parameters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iresultwarning.warningcode.html
+++ b/vNext/docs/sdk-backend-spi.iresultwarning.warningcode.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isanalyticalbackenderror.html
+++ b/vNext/docs/sdk-backend-spi.isanalyticalbackenderror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isattributedescriptor.html
+++ b/vNext/docs/sdk-backend-spi.isattributedescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.isattributedisplayformmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isattributemetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.isattributemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iscatalogattribute.html
+++ b/vNext/docs/sdk-backend-spi.iscatalogattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iscatalogdatedataset.html
+++ b/vNext/docs/sdk-backend-spi.iscatalogdatedataset.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iscatalogfact.html
+++ b/vNext/docs/sdk-backend-spi.iscatalogfact.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iscatalogmeasure.html
+++ b/vNext/docs/sdk-backend-spi.iscatalogmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isdashboardmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.isdashboardmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isdatasetmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.isdatasetmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isdatatoolargeerror.html
+++ b/vNext/docs/sdk-backend-spi.isdatatoolargeerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isecuritysettingsservice.html
+++ b/vNext/docs/sdk-backend-spi.isecuritysettingsservice.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isecuritysettingsservice.isdashboardpluginurlvalid.html
+++ b/vNext/docs/sdk-backend-spi.isecuritysettingsservice.isdashboardpluginurlvalid.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
+++ b/vNext/docs/sdk-backend-spi.isecuritysettingsservice.isurlvalid.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
+++ b/vNext/docs/sdk-backend-spi.isecuritysettingsservice.scope.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iseparators.decimal.html
+++ b/vNext/docs/sdk-backend-spi.iseparators.decimal.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iseparators.html
+++ b/vNext/docs/sdk-backend-spi.iseparators.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iseparators.thousand.html
+++ b/vNext/docs/sdk-backend-spi.iseparators.thousand.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
+++ b/vNext/docs/sdk-backend-spi.isettings.adcataloggroupsexpanded.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
+++ b/vNext/docs/sdk-backend-spi.isettings.admeasurevaluefilternullaszerooption.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
+++ b/vNext/docs/sdk-backend-spi.isettings.disablekpidashboardheadlineunderline.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablealternativedisplayformselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableanalyticaldashboardpermissions.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableanalyticaldashboardpermissions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableapproxcount.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableapproxcount.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableaxislabelformat.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableaxislabelformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableaxisnameconfiguration.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableaxisnameviewbytwoattributes.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableaxisnameviewbytwoattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablebulletchart.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablebulletchart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablechartssorting.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablechartssorting.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableclickableattributeurl.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableclickableattributeurl.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablecompanylogoinembeddedui.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablecompanylogoinembeddedui.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablecustomcolorpicker.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enabledatasampling.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enabledatasampling.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enabledrilledinsightexport.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enabledrilledinsightexport.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableembedbuttoninkd.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablehidingofdatapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableinsighttoreport.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableinsighttoreport.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekdwidgetcustomheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekdzooming.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekdzooming.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltodashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltoinsight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboarddrilltourl.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardimplicitdrilldown.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardimplicitdrilldown.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardsaveasnew.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardschedule.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablekpidashboardschedulerecipients.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablemultipledates.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablemultipledates.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablepushpingeochart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablerenamingmeasuretometric.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablerenamingmeasuretometric.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enablesectionheaders.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enablesectionheaders.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enabletablecolumnsautoresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enabletablecolumnsgrowtofit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enabletablecolumnsmanualresizing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.enableweekfilters.html
+++ b/vNext/docs/sdk-backend-spi.isettings.enableweekfilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.hidekpidrillinembedded.html
+++ b/vNext/docs/sdk-backend-spi.isettings.hidekpidrillinembedded.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.html
+++ b/vNext/docs/sdk-backend-spi.isettings.html
@@ -122,7 +122,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.platformedition.html
+++ b/vNext/docs/sdk-backend-spi.isettings.platformedition.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
+++ b/vNext/docs/sdk-backend-spi.isettings.responsiveuidateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isfactmetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.isfactmetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ismeasuredescriptor.html
+++ b/vNext/docs/sdk-backend-spi.ismeasuredescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
+++ b/vNext/docs/sdk-backend-spi.ismeasuregroupdescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ismeasuremetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.ismeasuremetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
+++ b/vNext/docs/sdk-backend-spi.ismeasuremetadataobjectdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ismetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.ismetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isnodataerror.html
+++ b/vNext/docs/sdk-backend-spi.isnodataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isnotauthenticated.html
+++ b/vNext/docs/sdk-backend-spi.isnotauthenticated.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isnotimplemented.html
+++ b/vNext/docs/sdk-backend-spi.isnotimplemented.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isnotsupported.html
+++ b/vNext/docs/sdk-backend-spi.isnotsupported.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isprotecteddataerror.html
+++ b/vNext/docs/sdk-backend-spi.isprotecteddataerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isresultattributeheader.html
+++ b/vNext/docs/sdk-backend-spi.isresultattributeheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isresultmeasureheader.html
+++ b/vNext/docs/sdk-backend-spi.isresultmeasureheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isresulttotalheader.html
+++ b/vNext/docs/sdk-backend-spi.isresulttotalheader.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.istotaldescriptor.html
+++ b/vNext/docs/sdk-backend-spi.istotaldescriptor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isunexpectederror.html
+++ b/vNext/docs/sdk-backend-spi.isunexpectederror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isunexpectedresponseerror.html
+++ b/vNext/docs/sdk-backend-spi.isunexpectedresponseerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isuseraccessgrantee.html
+++ b/vNext/docs/sdk-backend-spi.isuseraccessgrantee.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isusergroupaccessgrantee.html
+++ b/vNext/docs/sdk-backend-spi.isusergroupaccessgrantee.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.isvariablemetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.isvariablemetadataobject.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itextexpressiontoken.html
+++ b/vNext/docs/sdk-backend-spi.itextexpressiontoken.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itextexpressiontoken.type.html
+++ b/vNext/docs/sdk-backend-spi.itextexpressiontoken.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itextexpressiontoken.value.html
+++ b/vNext/docs/sdk-backend-spi.itextexpressiontoken.value.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.analyticaldesigner.html
+++ b/vNext/docs/sdk-backend-spi.itheme.analyticaldesigner.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.button.html
+++ b/vNext/docs/sdk-backend-spi.itheme.button.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.chart.html
+++ b/vNext/docs/sdk-backend-spi.itheme.chart.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.dashboards.html
+++ b/vNext/docs/sdk-backend-spi.itheme.dashboards.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.html
+++ b/vNext/docs/sdk-backend-spi.itheme.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.kpi.html
+++ b/vNext/docs/sdk-backend-spi.itheme.kpi.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.modal.html
+++ b/vNext/docs/sdk-backend-spi.itheme.modal.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.palette.html
+++ b/vNext/docs/sdk-backend-spi.itheme.palette.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.table.html
+++ b/vNext/docs/sdk-backend-spi.itheme.table.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.tooltip.html
+++ b/vNext/docs/sdk-backend-spi.itheme.tooltip.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itheme.typography.html
+++ b/vNext/docs/sdk-backend-spi.itheme.typography.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.axiscolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.axiscolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.axislabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.axisvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.gridcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.legendvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.tooltipbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.tooltipbordercolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.tooltiplabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemechart.tooltipvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecolorfamily.base.html
+++ b/vNext/docs/sdk-backend-spi.ithemecolorfamily.base.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
+++ b/vNext/docs/sdk-backend-spi.ithemecolorfamily.contrast.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecolorfamily.dark.html
+++ b/vNext/docs/sdk-backend-spi.ithemecolorfamily.dark.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecolorfamily.html
+++ b/vNext/docs/sdk-backend-spi.ithemecolorfamily.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecolorfamily.light.html
+++ b/vNext/docs/sdk-backend-spi.ithemecolorfamily.light.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c0.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c1.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c2.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c3.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c4.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c5.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c6.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c7.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c8.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.c9.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.html
+++ b/vNext/docs/sdk-backend-spi.ithemecomplementarypalette.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemekpi.html
+++ b/vNext/docs/sdk-backend-spi.ithemekpi.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemekpi.primarymeasurecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemekpi.secondaryinfocolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemekpi.value.html
+++ b/vNext/docs/sdk-backend-spi.ithemekpi.value.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.complementary.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.complementary.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.error.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.error.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.info.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.info.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.primary.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.primary.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.success.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.success.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemepalette.warning.html
+++ b/vNext/docs/sdk-backend-spi.ithemepalette.warning.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.backgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.gridcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.gridcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.headerhoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.headerlabelcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.hoverbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.loadingiconcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.nullvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.subtotalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.totalbackgroundcolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.totalvaluecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetable.valuecolor.html
+++ b/vNext/docs/sdk-backend-spi.ithemetable.valuecolor.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetypography.font.html
+++ b/vNext/docs/sdk-backend-spi.ithemetypography.font.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetypography.fontbold.html
+++ b/vNext/docs/sdk-backend-spi.ithemetypography.fontbold.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemetypography.html
+++ b/vNext/docs/sdk-backend-spi.ithemetypography.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemewidgettitle.color.html
+++ b/vNext/docs/sdk-backend-spi.ithemewidgettitle.color.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemewidgettitle.html
+++ b/vNext/docs/sdk-backend-spi.ithemewidgettitle.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
+++ b/vNext/docs/sdk-backend-spi.ithemewidgettitle.textalign.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itotaldescriptor.html
+++ b/vNext/docs/sdk-backend-spi.itotaldescriptor.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
+++ b/vNext/docs/sdk-backend-spi.itotaldescriptor.totalheaderitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuseraccessgrantee.granteeref.html
+++ b/vNext/docs/sdk-backend-spi.iuseraccessgrantee.granteeref.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuseraccessgrantee.html
+++ b/vNext/docs/sdk-backend-spi.iuseraccessgrantee.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuseraccessgrantee.type.html
+++ b/vNext/docs/sdk-backend-spi.iuseraccessgrantee.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusergroupaccessgrantee.granteeref.html
+++ b/vNext/docs/sdk-backend-spi.iusergroupaccessgrantee.granteeref.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusergroupaccessgrantee.html
+++ b/vNext/docs/sdk-backend-spi.iusergroupaccessgrantee.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusergroupaccessgrantee.type.html
+++ b/vNext/docs/sdk-backend-spi.iusergroupaccessgrantee.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuserservice.getuser.html
+++ b/vNext/docs/sdk-backend-spi.iuserservice.getuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuserservice.html
+++ b/vNext/docs/sdk-backend-spi.iuserservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuserservice.settings.html
+++ b/vNext/docs/sdk-backend-spi.iuserservice.settings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusersettings.html
+++ b/vNext/docs/sdk-backend-spi.iusersettings.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusersettings.locale.html
+++ b/vNext/docs/sdk-backend-spi.iusersettings.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusersettings.separators.html
+++ b/vNext/docs/sdk-backend-spi.iusersettings.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusersettings.userid.html
+++ b/vNext/docs/sdk-backend-spi.iusersettings.userid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
+++ b/vNext/docs/sdk-backend-spi.iusersettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iusersettingsservice.html
+++ b/vNext/docs/sdk-backend-spi.iusersettingsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iuserworkspacesettings.html
+++ b/vNext/docs/sdk-backend-spi.iuserworkspacesettings.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ivariablemetadataobject.html
+++ b/vNext/docs/sdk-backend-spi.ivariablemetadataobject.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.ivariablemetadataobject.type.html
+++ b/vNext/docs/sdk-backend-spi.ivariablemetadataobject.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.elements.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattribute.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributedisplayforms.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getattributes.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.getcommonattributesbatch.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceattributesservice.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalog.availableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalog.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalog.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.forinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.foritems.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogavailableitemsfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.load.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactory.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.excludetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fordataset.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.fortypes.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.includetags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactorymethods.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.excludetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includedategranularities.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.includetags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.production.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogfactoryoptions.types.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.allitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.attributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.datedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.facts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.groups.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogmethods.measures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.allavailableitems.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availableattributes.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availabledatedatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablefacts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.availablemeasures.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.insight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacecatalogwithavailableitemsfactoryoptions.items.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedatasetsservice.getalldatasetsmeta.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedatasetsservice.getdatasets.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedatasetsservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedatasetsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedescriptor.description.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedescriptor.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedescriptor.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedescriptor.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedescriptor.id.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedescriptor.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedescriptor.isdemo.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedescriptor.parentworkspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacedescriptor.title.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacedescriptor.title.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacefactsservice.getfactdatasetmeta.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacefactsservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacefactsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.createinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.deleteinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsight.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencedobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightreferencingobjects.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsights.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getinsightwithaddedfilters.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclass.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.getvisualizationclasses.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceinsightsservice.updateinsight.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.createmeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.deletemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasureexpressiontokens.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasurereferencingobjects.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.getmeasurereferencingobjects.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacemeasuresservice.updatemeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacepermissions.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacepermissions.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacepermissionsservice.getpermissionsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacepermissionsservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacepermissionsservice.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesettings.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesettings.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesettings.workspace.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesettings.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesettingsservice.getsettings.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesettingsservice.getsettingsforcurrentuser.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesettingsservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesettingsservice.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesquery.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesquery.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesquery.query.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesquery.query.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesquery.withlimit.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesquery.withoffset.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesquery.withsearch.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesqueryfactory.forcurrentuser.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesqueryfactory.foruser.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesqueryfactory.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesqueryfactory.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacesqueryresult.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacesqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacestylingservice.getcolorpalette.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacestylingservice.gettheme.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspacestylingservice.html
+++ b/vNext/docs/sdk-backend-spi.iworkspacestylingservice.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.email.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.firstname.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.fullname.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.lastname.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.login.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.ref.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.status.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.status.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceuser.uri.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceuser.uri.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersquery.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersquery.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersquery.query.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersquery.query.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersquery.queryall.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersquery.withoptions.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.limit.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.offset.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersqueryoptions.search.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.iworkspaceusersqueryresult.html
+++ b/vNext/docs/sdk-backend-spi.iworkspaceusersqueryresult.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.metadataobject.html
+++ b/vNext/docs/sdk-backend-spi.metadataobject.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.metadataobjectid.html
+++ b/vNext/docs/sdk-backend-spi.metadataobjectid.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.nodataerror._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.nodataerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.nodataerror.dataview.html
+++ b/vNext/docs/sdk-backend-spi.nodataerror.dataview.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.nodataerror.html
+++ b/vNext/docs/sdk-backend-spi.nodataerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notauthenticated._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.notauthenticated._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
+++ b/vNext/docs/sdk-backend-spi.notauthenticated.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notauthenticated.html
+++ b/vNext/docs/sdk-backend-spi.notauthenticated.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notauthenticated.reason.html
+++ b/vNext/docs/sdk-backend-spi.notauthenticated.reason.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notauthenticatedhandler.html
+++ b/vNext/docs/sdk-backend-spi.notauthenticatedhandler.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notauthenticatedreason.html
+++ b/vNext/docs/sdk-backend-spi.notauthenticatedreason.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notimplemented._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.notimplemented._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notimplemented.html
+++ b/vNext/docs/sdk-backend-spi.notimplemented.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notsupported._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.notsupported._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.notsupported.html
+++ b/vNext/docs/sdk-backend-spi.notsupported.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.platformedition.html
+++ b/vNext/docs/sdk-backend-spi.platformedition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.prepareexecution.html
+++ b/vNext/docs/sdk-backend-spi.prepareexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.protecteddataerror._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.protecteddataerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.protecteddataerror.html
+++ b/vNext/docs/sdk-backend-spi.protecteddataerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.resultheadername.html
+++ b/vNext/docs/sdk-backend-spi.resultheadername.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.sharestatus.html
+++ b/vNext/docs/sdk-backend-spi.sharestatus.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.supportedinsightreferencetypes.html
+++ b/vNext/docs/sdk-backend-spi.supportedinsightreferencetypes.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.themecolor.html
+++ b/vNext/docs/sdk-backend-spi.themecolor.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.themefonturi.html
+++ b/vNext/docs/sdk-backend-spi.themefonturi.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.unexpectederror._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.unexpectederror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.unexpectederror.html
+++ b/vNext/docs/sdk-backend-spi.unexpectederror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
+++ b/vNext/docs/sdk-backend-spi.unexpectedresponseerror._constructor_.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.unexpectedresponseerror.html
+++ b/vNext/docs/sdk-backend-spi.unexpectedresponseerror.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
+++ b/vNext/docs/sdk-backend-spi.unexpectedresponseerror.httpstatus.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
+++ b/vNext/docs/sdk-backend-spi.unexpectedresponseerror.responsebody.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.validationcontext.html
+++ b/vNext/docs/sdk-backend-spi.validationcontext.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-backend-spi.workspacepermission.html
+++ b/vNext/docs/sdk-backend-spi.workspacepermission.html
@@ -147,7 +147,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.absolutedatefiltervalues.html
+++ b/vNext/docs/sdk-model.absolutedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.alltimegranularity.html
+++ b/vNext/docs/sdk-model.alltimegranularity.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.anyattribute.html
+++ b/vNext/docs/sdk-model.anyattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.anybucket.html
+++ b/vNext/docs/sdk-model.anybucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.anymeasure.html
+++ b/vNext/docs/sdk-model.anymeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.applyratiorule.html
+++ b/vNext/docs/sdk-model.applyratiorule.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.areobjrefsequal.html
+++ b/vNext/docs/sdk-model.areobjrefsequal.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
+++ b/vNext/docs/sdk-model.arithmeticmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
+++ b/vNext/docs/sdk-model.arithmeticmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasurebuilder.html
+++ b/vNext/docs/sdk-model.arithmeticmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasurebuilder.operands.html
+++ b/vNext/docs/sdk-model.arithmeticmeasurebuilder.operands.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasurebuilder.operator.html
+++ b/vNext/docs/sdk-model.arithmeticmeasurebuilder.operator.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasurebuilderinput.html
+++ b/vNext/docs/sdk-model.arithmeticmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.arithmeticmeasureoperator.html
+++ b/vNext/docs/sdk-model.arithmeticmeasureoperator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributealias.html
+++ b/vNext/docs/sdk-model.attributealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.alias.html
+++ b/vNext/docs/sdk-model.attributebuilder.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.build.html
+++ b/vNext/docs/sdk-model.attributebuilder.build.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.defaultlocalid.html
+++ b/vNext/docs/sdk-model.attributebuilder.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.displayform.html
+++ b/vNext/docs/sdk-model.attributebuilder.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.html
+++ b/vNext/docs/sdk-model.attributebuilder.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.localid.html
+++ b/vNext/docs/sdk-model.attributebuilder.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilder.noalias.html
+++ b/vNext/docs/sdk-model.attributebuilder.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributebuilderinput.html
+++ b/vNext/docs/sdk-model.attributebuilderinput.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributedisplayformref.html
+++ b/vNext/docs/sdk-model.attributedisplayformref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributeidentifier.html
+++ b/vNext/docs/sdk-model.attributeidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributeinbucket.html
+++ b/vNext/docs/sdk-model.attributeinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributelocalid.html
+++ b/vNext/docs/sdk-model.attributelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributelocatorelement.html
+++ b/vNext/docs/sdk-model.attributelocatorelement.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributelocatoridentifier.html
+++ b/vNext/docs/sdk-model.attributelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributemodifications.html
+++ b/vNext/docs/sdk-model.attributemodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributepredicate.html
+++ b/vNext/docs/sdk-model.attributepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributesfind.html
+++ b/vNext/docs/sdk-model.attributesfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.attributeuri.html
+++ b/vNext/docs/sdk-model.attributeuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketattribute.html
+++ b/vNext/docs/sdk-model.bucketattribute.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketattributeindex.html
+++ b/vNext/docs/sdk-model.bucketattributeindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketattributes.html
+++ b/vNext/docs/sdk-model.bucketattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketisempty.html
+++ b/vNext/docs/sdk-model.bucketisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketitemlocalid.html
+++ b/vNext/docs/sdk-model.bucketitemlocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketitemmodifications.html
+++ b/vNext/docs/sdk-model.bucketitemmodifications.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketitemreduce.html
+++ b/vNext/docs/sdk-model.bucketitemreduce.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketitemreducer.html
+++ b/vNext/docs/sdk-model.bucketitemreducer.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketitems.html
+++ b/vNext/docs/sdk-model.bucketitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketmeasure.html
+++ b/vNext/docs/sdk-model.bucketmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketmeasureindex.html
+++ b/vNext/docs/sdk-model.bucketmeasureindex.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketmeasures.html
+++ b/vNext/docs/sdk-model.bucketmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketmodifyitems.html
+++ b/vNext/docs/sdk-model.bucketmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketpredicate.html
+++ b/vNext/docs/sdk-model.bucketpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsattributes.html
+++ b/vNext/docs/sdk-model.bucketsattributes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsbyid.html
+++ b/vNext/docs/sdk-model.bucketsbyid.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsettotals.html
+++ b/vNext/docs/sdk-model.bucketsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsfind.html
+++ b/vNext/docs/sdk-model.bucketsfind.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsfindattribute.html
+++ b/vNext/docs/sdk-model.bucketsfindattribute.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsfindmeasure.html
+++ b/vNext/docs/sdk-model.bucketsfindmeasure.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsisempty.html
+++ b/vNext/docs/sdk-model.bucketsisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsitems.html
+++ b/vNext/docs/sdk-model.bucketsitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsmeasures.html
+++ b/vNext/docs/sdk-model.bucketsmeasures.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsmodifyitem.html
+++ b/vNext/docs/sdk-model.bucketsmodifyitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketsreduceitem.html
+++ b/vNext/docs/sdk-model.bucketsreduceitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.bucketstotals.html
+++ b/vNext/docs/sdk-model.bucketstotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.buckettotals.html
+++ b/vNext/docs/sdk-model.buckettotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.colorpaletteitemtorgb.html
+++ b/vNext/docs/sdk-model.colorpaletteitemtorgb.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.colorpalettetocolors.html
+++ b/vNext/docs/sdk-model.colorpalettetocolors.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.comparatordirection.html
+++ b/vNext/docs/sdk-model.comparatordirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.comparisonconditionoperator.html
+++ b/vNext/docs/sdk-model.comparisonconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.computeratiorule.html
+++ b/vNext/docs/sdk-model.computeratiorule.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dateattributegranularity.html
+++ b/vNext/docs/sdk-model.dateattributegranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dategranularity.html
+++ b/vNext/docs/sdk-model.dategranularity.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defaultdimensionsgenerator.html
+++ b/vNext/docs/sdk-model.defaultdimensionsgenerator.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.deffingerprint.html
+++ b/vNext/docs/sdk-model.deffingerprint.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defsetdimensions.html
+++ b/vNext/docs/sdk-model.defsetdimensions.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defsetexecconfig.html
+++ b/vNext/docs/sdk-model.defsetexecconfig.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defsetpostprocessing.html
+++ b/vNext/docs/sdk-model.defsetpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defsetsorts.html
+++ b/vNext/docs/sdk-model.defsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.deftotals.html
+++ b/vNext/docs/sdk-model.deftotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defwithdateformat.html
+++ b/vNext/docs/sdk-model.defwithdateformat.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defwithdimensions.html
+++ b/vNext/docs/sdk-model.defwithdimensions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defwithexecconfig.html
+++ b/vNext/docs/sdk-model.defwithexecconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defwithfilters.html
+++ b/vNext/docs/sdk-model.defwithfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defwithpostprocessing.html
+++ b/vNext/docs/sdk-model.defwithpostprocessing.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.defwithsorting.html
+++ b/vNext/docs/sdk-model.defwithsorting.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.deserializeobjref.html
+++ b/vNext/docs/sdk-model.deserializeobjref.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dimensiongenerator.html
+++ b/vNext/docs/sdk-model.dimensiongenerator.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dimensionitem.html
+++ b/vNext/docs/sdk-model.dimensionitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dimensionsettotals.html
+++ b/vNext/docs/sdk-model.dimensionsettotals.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dimensionsfinditem.html
+++ b/vNext/docs/sdk-model.dimensionsfinditem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.dimensiontotals.html
+++ b/vNext/docs/sdk-model.dimensiontotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.disablecomputeratio.html
+++ b/vNext/docs/sdk-model.disablecomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.emptydef.html
+++ b/vNext/docs/sdk-model.emptydef.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.factorynotationfor.html
+++ b/vNext/docs/sdk-model.factorynotationfor.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.filterattributeelements.html
+++ b/vNext/docs/sdk-model.filterattributeelements.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.filterattributeelements_1.html
+++ b/vNext/docs/sdk-model.filterattributeelements_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.filterisempty.html
+++ b/vNext/docs/sdk-model.filterisempty.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.filtermeasureref.html
+++ b/vNext/docs/sdk-model.filtermeasureref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.filterobjref.html
+++ b/vNext/docs/sdk-model.filterobjref.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.filterobjref_1.html
+++ b/vNext/docs/sdk-model.filterobjref_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.guidtype.html
+++ b/vNext/docs/sdk-model.guidtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.html
+++ b/vNext/docs/sdk-model.html
@@ -446,7 +446,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
+++ b/vNext/docs/sdk-model.iabsolutedatefilter.absolutedatefilter.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iabsolutedatefilter.html
+++ b/vNext/docs/sdk-model.iabsolutedatefilter.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iabsolutedatefiltervalues.from.html
+++ b/vNext/docs/sdk-model.iabsolutedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iabsolutedatefiltervalues.html
+++ b/vNext/docs/sdk-model.iabsolutedatefiltervalues.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iabsolutedatefiltervalues.to.html
+++ b/vNext/docs/sdk-model.iabsolutedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
+++ b/vNext/docs/sdk-model.iarithmeticmeasuredefinition.arithmeticmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iarithmeticmeasuredefinition.html
+++ b/vNext/docs/sdk-model.iarithmeticmeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattribute.attribute.html
+++ b/vNext/docs/sdk-model.iattribute.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattribute.html
+++ b/vNext/docs/sdk-model.iattribute.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributeelements.html
+++ b/vNext/docs/sdk-model.iattributeelements.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributeelementsbyref.html
+++ b/vNext/docs/sdk-model.iattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributeelementsbyref.uris.html
+++ b/vNext/docs/sdk-model.iattributeelementsbyref.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributeelementsbyvalue.html
+++ b/vNext/docs/sdk-model.iattributeelementsbyvalue.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributeelementsbyvalue.values.html
+++ b/vNext/docs/sdk-model.iattributeelementsbyvalue.values.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributefilter.html
+++ b/vNext/docs/sdk-model.iattributefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
+++ b/vNext/docs/sdk-model.iattributelocatoritem.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributelocatoritem.html
+++ b/vNext/docs/sdk-model.iattributelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributeormeasure.html
+++ b/vNext/docs/sdk-model.iattributeormeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributesortitem.attributesortitem.html
+++ b/vNext/docs/sdk-model.iattributesortitem.attributesortitem.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributesortitem.html
+++ b/vNext/docs/sdk-model.iattributesortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributesorttarget.attributeidentifier.html
+++ b/vNext/docs/sdk-model.iattributesorttarget.attributeidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributesorttarget.html
+++ b/vNext/docs/sdk-model.iattributesorttarget.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributesorttype.aggregation.html
+++ b/vNext/docs/sdk-model.iattributesorttype.aggregation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iattributesorttype.html
+++ b/vNext/docs/sdk-model.iattributesorttype.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditable.html
+++ b/vNext/docs/sdk-model.iauditable.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditabledates.created.html
+++ b/vNext/docs/sdk-model.iauditabledates.created.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditabledates.html
+++ b/vNext/docs/sdk-model.iauditabledates.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditabledates.updated.html
+++ b/vNext/docs/sdk-model.iauditabledates.updated.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditableusers.createdby.html
+++ b/vNext/docs/sdk-model.iauditableusers.createdby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditableusers.html
+++ b/vNext/docs/sdk-model.iauditableusers.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iauditableusers.updatedby.html
+++ b/vNext/docs/sdk-model.iauditableusers.updatedby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ibucket.html
+++ b/vNext/docs/sdk-model.ibucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ibucket.items.html
+++ b/vNext/docs/sdk-model.ibucket.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ibucket.localidentifier.html
+++ b/vNext/docs/sdk-model.ibucket.localidentifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ibucket.totals.html
+++ b/vNext/docs/sdk-model.ibucket.totals.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolor.html
+++ b/vNext/docs/sdk-model.icolor.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorfrompalette.html
+++ b/vNext/docs/sdk-model.icolorfrompalette.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorfrompalette.type.html
+++ b/vNext/docs/sdk-model.icolorfrompalette.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorfrompalette.value.html
+++ b/vNext/docs/sdk-model.icolorfrompalette.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolormappingitem.color.html
+++ b/vNext/docs/sdk-model.icolormappingitem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolormappingitem.html
+++ b/vNext/docs/sdk-model.icolormappingitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolormappingitem.id.html
+++ b/vNext/docs/sdk-model.icolormappingitem.id.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorpalette.html
+++ b/vNext/docs/sdk-model.icolorpalette.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorpaletteitem.fill.html
+++ b/vNext/docs/sdk-model.icolorpaletteitem.fill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorpaletteitem.guid.html
+++ b/vNext/docs/sdk-model.icolorpaletteitem.guid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icolorpaletteitem.html
+++ b/vNext/docs/sdk-model.icolorpaletteitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icomparator.html
+++ b/vNext/docs/sdk-model.icomparator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icomparisoncondition.comparison.html
+++ b/vNext/docs/sdk-model.icomparisoncondition.comparison.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.icomparisoncondition.html
+++ b/vNext/docs/sdk-model.icomparisoncondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idatefilter.html
+++ b/vNext/docs/sdk-model.idatefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.identifier.html
+++ b/vNext/docs/sdk-model.identifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.identifierref.html
+++ b/vNext/docs/sdk-model.identifierref.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idimension.html
+++ b/vNext/docs/sdk-model.idimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idimension.itemidentifiers.html
+++ b/vNext/docs/sdk-model.idimension.itemidentifiers.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idimension.totals.html
+++ b/vNext/docs/sdk-model.idimension.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idmatchattribute.html
+++ b/vNext/docs/sdk-model.idmatchattribute.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idmatchbucket.html
+++ b/vNext/docs/sdk-model.idmatchbucket.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idmatchmeasure.html
+++ b/vNext/docs/sdk-model.idmatchmeasure.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.idref.html
+++ b/vNext/docs/sdk-model.idref.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
+++ b/vNext/docs/sdk-model.iexecutionconfig.datasamplingpercentage.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutionconfig.html
+++ b/vNext/docs/sdk-model.iexecutionconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.attributes.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.attributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.buckets.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.buckets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.dimensions.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.dimensions.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.executionconfig.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.executionconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.filters.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.measures.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.postprocessing.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.postprocessing.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.sortby.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iexecutiondefinition.workspace.html
+++ b/vNext/docs/sdk-model.iexecutiondefinition.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ifilter.html
+++ b/vNext/docs/sdk-model.ifilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iinsight.html
+++ b/vNext/docs/sdk-model.iinsight.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iinsightdefinition.html
+++ b/vNext/docs/sdk-model.iinsightdefinition.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ilocatoritem.html
+++ b/vNext/docs/sdk-model.ilocatoritem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasure.html
+++ b/vNext/docs/sdk-model.imeasure.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasure.measure.html
+++ b/vNext/docs/sdk-model.imeasure.measure.html
@@ -24,7 +24,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuredefinition.html
+++ b/vNext/docs/sdk-model.imeasuredefinition.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuredefinition.measuredefinition.html
+++ b/vNext/docs/sdk-model.imeasuredefinition.measuredefinition.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuredefinitiontype.html
+++ b/vNext/docs/sdk-model.imeasuredefinitiontype.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasurefilter.html
+++ b/vNext/docs/sdk-model.imeasurefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasurelocatoritem.html
+++ b/vNext/docs/sdk-model.imeasurelocatoritem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
+++ b/vNext/docs/sdk-model.imeasurelocatoritem.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuresortitem.html
+++ b/vNext/docs/sdk-model.imeasuresortitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuresortitem.measuresortitem.html
+++ b/vNext/docs/sdk-model.imeasuresortitem.measuresortitem.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuresorttarget.html
+++ b/vNext/docs/sdk-model.imeasuresorttarget.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuresorttarget.locators.html
+++ b/vNext/docs/sdk-model.imeasuresorttarget.locators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuretitle.html
+++ b/vNext/docs/sdk-model.imeasuretitle.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasuretitle.measure.html
+++ b/vNext/docs/sdk-model.imeasuretitle.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasurevaluefilter.html
+++ b/vNext/docs/sdk-model.imeasurevaluefilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
+++ b/vNext/docs/sdk-model.imeasurevaluefilter.measurevaluefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.inegativeattributefilter.html
+++ b/vNext/docs/sdk-model.inegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
+++ b/vNext/docs/sdk-model.inegativeattributefilter.negativeattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightattributes.html
+++ b/vNext/docs/sdk-model.insightattributes.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightbucket.html
+++ b/vNext/docs/sdk-model.insightbucket.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightbuckets.html
+++ b/vNext/docs/sdk-model.insightbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightcreated.html
+++ b/vNext/docs/sdk-model.insightcreated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightcreatedby.html
+++ b/vNext/docs/sdk-model.insightcreatedby.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightdisplayformusage.html
+++ b/vNext/docs/sdk-model.insightdisplayformusage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightfilters.html
+++ b/vNext/docs/sdk-model.insightfilters.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighthasattributes.html
+++ b/vNext/docs/sdk-model.insighthasattributes.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighthasdatadefined.html
+++ b/vNext/docs/sdk-model.insighthasdatadefined.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighthasmeasures.html
+++ b/vNext/docs/sdk-model.insighthasmeasures.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightid.html
+++ b/vNext/docs/sdk-model.insightid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightislocked.html
+++ b/vNext/docs/sdk-model.insightislocked.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightitems.html
+++ b/vNext/docs/sdk-model.insightitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightmeasures.html
+++ b/vNext/docs/sdk-model.insightmeasures.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightmodifyitems.html
+++ b/vNext/docs/sdk-model.insightmodifyitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightproperties.html
+++ b/vNext/docs/sdk-model.insightproperties.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightreduceitems.html
+++ b/vNext/docs/sdk-model.insightreduceitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightref.html
+++ b/vNext/docs/sdk-model.insightref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsanitize.html
+++ b/vNext/docs/sdk-model.insightsanitize.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsetbuckets.html
+++ b/vNext/docs/sdk-model.insightsetbuckets.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsetfilters.html
+++ b/vNext/docs/sdk-model.insightsetfilters.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsetproperties.html
+++ b/vNext/docs/sdk-model.insightsetproperties.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsetsorts.html
+++ b/vNext/docs/sdk-model.insightsetsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsorts.html
+++ b/vNext/docs/sdk-model.insightsorts.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightsummary.html
+++ b/vNext/docs/sdk-model.insightsummary.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighttags.html
+++ b/vNext/docs/sdk-model.insighttags.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighttitle.html
+++ b/vNext/docs/sdk-model.insighttitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighttotals.html
+++ b/vNext/docs/sdk-model.insighttotals.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightupdated.html
+++ b/vNext/docs/sdk-model.insightupdated.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insightupdatedby.html
+++ b/vNext/docs/sdk-model.insightupdatedby.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.insighturi.html
+++ b/vNext/docs/sdk-model.insighturi.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.inullablefilter.html
+++ b/vNext/docs/sdk-model.inullablefilter.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipopmeasuredefinition.html
+++ b/vNext/docs/sdk-model.ipopmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
+++ b/vNext/docs/sdk-model.ipopmeasuredefinition.popmeasuredefinition.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipositiveattributefilter.html
+++ b/vNext/docs/sdk-model.ipositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
+++ b/vNext/docs/sdk-model.ipositiveattributefilter.positiveattributefilter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipostprocessing.dateformat.html
+++ b/vNext/docs/sdk-model.ipostprocessing.dateformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipostprocessing.html
+++ b/vNext/docs/sdk-model.ipostprocessing.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperioddatedataset.dataset.html
+++ b/vNext/docs/sdk-model.ipreviousperioddatedataset.dataset.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperioddatedataset.html
+++ b/vNext/docs/sdk-model.ipreviousperioddatedataset.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
+++ b/vNext/docs/sdk-model.ipreviousperioddatedataset.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
+++ b/vNext/docs/sdk-model.ipreviousperioddatedatasetsimple.dataset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperioddatedatasetsimple.html
+++ b/vNext/docs/sdk-model.ipreviousperioddatedatasetsimple.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
+++ b/vNext/docs/sdk-model.ipreviousperioddatedatasetsimple.periodsago.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperiodmeasuredefinition.html
+++ b/vNext/docs/sdk-model.ipreviousperiodmeasuredefinition.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
+++ b/vNext/docs/sdk-model.ipreviousperiodmeasuredefinition.previousperiodmeasure.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irangecondition.html
+++ b/vNext/docs/sdk-model.irangecondition.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irangecondition.range.html
+++ b/vNext/docs/sdk-model.irangecondition.range.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irankingfilter.html
+++ b/vNext/docs/sdk-model.irankingfilter.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irankingfilter.rankingfilter.html
+++ b/vNext/docs/sdk-model.irankingfilter.rankingfilter.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irelativedatefilter.html
+++ b/vNext/docs/sdk-model.irelativedatefilter.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irelativedatefiltervalues.from.html
+++ b/vNext/docs/sdk-model.irelativedatefiltervalues.from.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irelativedatefiltervalues.granularity.html
+++ b/vNext/docs/sdk-model.irelativedatefiltervalues.granularity.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irelativedatefiltervalues.html
+++ b/vNext/docs/sdk-model.irelativedatefiltervalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irelativedatefiltervalues.to.html
+++ b/vNext/docs/sdk-model.irelativedatefiltervalues.to.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolor.html
+++ b/vNext/docs/sdk-model.irgbcolor.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolor.type.html
+++ b/vNext/docs/sdk-model.irgbcolor.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolor.value.html
+++ b/vNext/docs/sdk-model.irgbcolor.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolorvalue.b.html
+++ b/vNext/docs/sdk-model.irgbcolorvalue.b.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolorvalue.g.html
+++ b/vNext/docs/sdk-model.irgbcolorvalue.g.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolorvalue.html
+++ b/vNext/docs/sdk-model.irgbcolorvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.irgbcolorvalue.r.html
+++ b/vNext/docs/sdk-model.irgbcolorvalue.r.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isabsolutedatefilter.html
+++ b/vNext/docs/sdk-model.isabsolutedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isadhocmeasure.html
+++ b/vNext/docs/sdk-model.isadhocmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isalltimedatefilter.html
+++ b/vNext/docs/sdk-model.isalltimedatefilter.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isarithmeticmeasure.html
+++ b/vNext/docs/sdk-model.isarithmeticmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isarithmeticmeasuredefinition.html
+++ b/vNext/docs/sdk-model.isarithmeticmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattribute.html
+++ b/vNext/docs/sdk-model.isattribute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributeareasort.html
+++ b/vNext/docs/sdk-model.isattributeareasort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributeelementsbyref.html
+++ b/vNext/docs/sdk-model.isattributeelementsbyref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributeelementsbyvalue.html
+++ b/vNext/docs/sdk-model.isattributeelementsbyvalue.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributefilter.html
+++ b/vNext/docs/sdk-model.isattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributelocator.html
+++ b/vNext/docs/sdk-model.isattributelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributesort.html
+++ b/vNext/docs/sdk-model.isattributesort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isattributevaluesort.html
+++ b/vNext/docs/sdk-model.isattributevaluesort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isbucket.html
+++ b/vNext/docs/sdk-model.isbucket.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iscolorfrompalette.html
+++ b/vNext/docs/sdk-model.iscolorfrompalette.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iscomparisoncondition.html
+++ b/vNext/docs/sdk-model.iscomparisoncondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iscomparisonconditionoperator.html
+++ b/vNext/docs/sdk-model.iscomparisonconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isdatefilter.html
+++ b/vNext/docs/sdk-model.isdatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isdimension.html
+++ b/vNext/docs/sdk-model.isdimension.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isfilter.html
+++ b/vNext/docs/sdk-model.isfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isidentifierref.html
+++ b/vNext/docs/sdk-model.isidentifierref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isinsight.html
+++ b/vNext/docs/sdk-model.isinsight.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.islocalidref.html
+++ b/vNext/docs/sdk-model.islocalidref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ismeasure.html
+++ b/vNext/docs/sdk-model.ismeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ismeasuredefinition.html
+++ b/vNext/docs/sdk-model.ismeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ismeasureformatinpercent.html
+++ b/vNext/docs/sdk-model.ismeasureformatinpercent.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ismeasurelocator.html
+++ b/vNext/docs/sdk-model.ismeasurelocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ismeasuresort.html
+++ b/vNext/docs/sdk-model.ismeasuresort.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ismeasurevaluefilter.html
+++ b/vNext/docs/sdk-model.ismeasurevaluefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isnegativeattributefilter.html
+++ b/vNext/docs/sdk-model.isnegativeattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isobjref.html
+++ b/vNext/docs/sdk-model.isobjref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isortdirection.direction.html
+++ b/vNext/docs/sdk-model.isortdirection.direction.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isortdirection.html
+++ b/vNext/docs/sdk-model.isortdirection.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isortitem.html
+++ b/vNext/docs/sdk-model.isortitem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ispopmeasure.html
+++ b/vNext/docs/sdk-model.ispopmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ispopmeasuredefinition.html
+++ b/vNext/docs/sdk-model.ispopmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ispositiveattributefilter.html
+++ b/vNext/docs/sdk-model.ispositiveattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ispreviousperiodmeasure.html
+++ b/vNext/docs/sdk-model.ispreviousperiodmeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ispreviousperiodmeasuredefinition.html
+++ b/vNext/docs/sdk-model.ispreviousperiodmeasuredefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.israngecondition.html
+++ b/vNext/docs/sdk-model.israngecondition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.israngeconditionoperator.html
+++ b/vNext/docs/sdk-model.israngeconditionoperator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isrankingfilter.html
+++ b/vNext/docs/sdk-model.isrankingfilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isrelativedatefilter.html
+++ b/vNext/docs/sdk-model.isrelativedatefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isrgbcolor.html
+++ b/vNext/docs/sdk-model.isrgbcolor.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.issimplemeasure.html
+++ b/vNext/docs/sdk-model.issimplemeasure.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.istotal.html
+++ b/vNext/docs/sdk-model.istotal.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.isuriref.html
+++ b/vNext/docs/sdk-model.isuriref.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.itemindimension.html
+++ b/vNext/docs/sdk-model.itemindimension.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.itotal.alias.html
+++ b/vNext/docs/sdk-model.itotal.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.itotal.attributeidentifier.html
+++ b/vNext/docs/sdk-model.itotal.attributeidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.itotal.html
+++ b/vNext/docs/sdk-model.itotal.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.itotal.measureidentifier.html
+++ b/vNext/docs/sdk-model.itotal.measureidentifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.itotal.type.html
+++ b/vNext/docs/sdk-model.itotal.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.email.html
+++ b/vNext/docs/sdk-model.iuser.email.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.firstname.html
+++ b/vNext/docs/sdk-model.iuser.firstname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.fullname.html
+++ b/vNext/docs/sdk-model.iuser.fullname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.html
+++ b/vNext/docs/sdk-model.iuser.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.lastname.html
+++ b/vNext/docs/sdk-model.iuser.lastname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.login.html
+++ b/vNext/docs/sdk-model.iuser.login.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.organizationname.html
+++ b/vNext/docs/sdk-model.iuser.organizationname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.iuser.ref.html
+++ b/vNext/docs/sdk-model.iuser.ref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ivisualizationclass.html
+++ b/vNext/docs/sdk-model.ivisualizationclass.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.ivisualizationclass.visualizationclass.html
+++ b/vNext/docs/sdk-model.ivisualizationclass.visualizationclass.html
@@ -27,7 +27,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.localidref.html
+++ b/vNext/docs/sdk-model.localidref.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureaggregation.html
+++ b/vNext/docs/sdk-model.measureaggregation.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurealias.html
+++ b/vNext/docs/sdk-model.measurealias.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurearithmeticoperands.html
+++ b/vNext/docs/sdk-model.measurearithmeticoperands.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurearithmeticoperands_1.html
+++ b/vNext/docs/sdk-model.measurearithmeticoperands_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurearithmeticoperator.html
+++ b/vNext/docs/sdk-model.measurearithmeticoperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurearithmeticoperator_1.html
+++ b/vNext/docs/sdk-model.measurearithmeticoperator_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.aggregation.html
+++ b/vNext/docs/sdk-model.measurebuilder.aggregation.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.builddefinition.html
+++ b/vNext/docs/sdk-model.measurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.defaultaggregation.html
+++ b/vNext/docs/sdk-model.measurebuilder.defaultaggregation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.filters.html
+++ b/vNext/docs/sdk-model.measurebuilder.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.generatelocalid.html
+++ b/vNext/docs/sdk-model.measurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.html
+++ b/vNext/docs/sdk-model.measurebuilder.html
@@ -104,7 +104,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.measureitem.html
+++ b/vNext/docs/sdk-model.measurebuilder.measureitem.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.nofilters.html
+++ b/vNext/docs/sdk-model.measurebuilder.nofilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.noratio.html
+++ b/vNext/docs/sdk-model.measurebuilder.noratio.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilder.ratio.html
+++ b/vNext/docs/sdk-model.measurebuilder.ratio.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.alias.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.alias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.build.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.build.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.builddefinition.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.builddefinition.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.customlocalid.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.customlocalid.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.defaultformat.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.defaultformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.defaultlocalid.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.defaultlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.format.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.format.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.generatelocalid.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.generatelocalid.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.html
@@ -107,7 +107,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.initializefromexisting.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.initializefromexisting.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.localid.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.localid.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.noalias.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.noalias.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.notitle.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.notitle.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurebuilderbase.title.html
+++ b/vNext/docs/sdk-model.measurebuilderbase.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measuredoescomputeratio.html
+++ b/vNext/docs/sdk-model.measuredoescomputeratio.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureenvelope.html
+++ b/vNext/docs/sdk-model.measureenvelope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurefilters.html
+++ b/vNext/docs/sdk-model.measurefilters.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureformat.html
+++ b/vNext/docs/sdk-model.measureformat.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measuregroupidentifier.html
+++ b/vNext/docs/sdk-model.measuregroupidentifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureidentifier.html
+++ b/vNext/docs/sdk-model.measureidentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureinbucket.html
+++ b/vNext/docs/sdk-model.measureinbucket.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureitem.html
+++ b/vNext/docs/sdk-model.measureitem.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureitem_1.html
+++ b/vNext/docs/sdk-model.measureitem_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurelocalid.html
+++ b/vNext/docs/sdk-model.measurelocalid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurelocatoridentifier.html
+++ b/vNext/docs/sdk-model.measurelocatoridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measuremasteridentifier.html
+++ b/vNext/docs/sdk-model.measuremasteridentifier.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measuremasteridentifier_1.html
+++ b/vNext/docs/sdk-model.measuremasteridentifier_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measuremodifications.html
+++ b/vNext/docs/sdk-model.measuremodifications.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureorlocalid.html
+++ b/vNext/docs/sdk-model.measureorlocalid.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurepopattribute.html
+++ b/vNext/docs/sdk-model.measurepopattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurepopattribute_1.html
+++ b/vNext/docs/sdk-model.measurepopattribute_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurepredicate.html
+++ b/vNext/docs/sdk-model.measurepredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurepreviousperioddatedatasets.html
+++ b/vNext/docs/sdk-model.measurepreviousperioddatedatasets.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurepreviousperioddatedatasets_1.html
+++ b/vNext/docs/sdk-model.measurepreviousperioddatedatasets_1.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measuretitle.html
+++ b/vNext/docs/sdk-model.measuretitle.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measureuri.html
+++ b/vNext/docs/sdk-model.measureuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurevaluefiltercondition.html
+++ b/vNext/docs/sdk-model.measurevaluefiltercondition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurevaluefiltermeasure.html
+++ b/vNext/docs/sdk-model.measurevaluefiltermeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.measurevaluefilteroperator.html
+++ b/vNext/docs/sdk-model.measurevaluefilteroperator.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.modifyattribute.html
+++ b/vNext/docs/sdk-model.modifyattribute.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.modifymeasure.html
+++ b/vNext/docs/sdk-model.modifymeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.modifypopmeasure.html
+++ b/vNext/docs/sdk-model.modifypopmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.modifypreviousperiodmeasure.html
+++ b/vNext/docs/sdk-model.modifypreviousperiodmeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.modifysimplemeasure.html
+++ b/vNext/docs/sdk-model.modifysimplemeasure.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newabsolutedatefilter.html
+++ b/vNext/docs/sdk-model.newabsolutedatefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newalltimefilter.html
+++ b/vNext/docs/sdk-model.newalltimefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newarithmeticmeasure.html
+++ b/vNext/docs/sdk-model.newarithmeticmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newattribute.html
+++ b/vNext/docs/sdk-model.newattribute.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newattributeareasort.html
+++ b/vNext/docs/sdk-model.newattributeareasort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newattributelocator.html
+++ b/vNext/docs/sdk-model.newattributelocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newattributesort.html
+++ b/vNext/docs/sdk-model.newattributesort.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newbucket.html
+++ b/vNext/docs/sdk-model.newbucket.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newdefforbuckets.html
+++ b/vNext/docs/sdk-model.newdefforbuckets.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newdefforinsight.html
+++ b/vNext/docs/sdk-model.newdefforinsight.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newdefforitems.html
+++ b/vNext/docs/sdk-model.newdefforitems.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newdimension.html
+++ b/vNext/docs/sdk-model.newdimension.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newmeasure.html
+++ b/vNext/docs/sdk-model.newmeasure.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newmeasuresort.html
+++ b/vNext/docs/sdk-model.newmeasuresort.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newmeasuresortfromlocators.html
+++ b/vNext/docs/sdk-model.newmeasuresortfromlocators.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newmeasurevaluefilter.html
+++ b/vNext/docs/sdk-model.newmeasurevaluefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newmeasurevaluefilter_1.html
+++ b/vNext/docs/sdk-model.newmeasurevaluefilter_1.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newnegativeattributefilter.html
+++ b/vNext/docs/sdk-model.newnegativeattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newpopmeasure.html
+++ b/vNext/docs/sdk-model.newpopmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newpositiveattributefilter.html
+++ b/vNext/docs/sdk-model.newpositiveattributefilter.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newpreviousperiodmeasure.html
+++ b/vNext/docs/sdk-model.newpreviousperiodmeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newrankingfilter.html
+++ b/vNext/docs/sdk-model.newrankingfilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newrankingfilter_1.html
+++ b/vNext/docs/sdk-model.newrankingfilter_1.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newrelativedatefilter.html
+++ b/vNext/docs/sdk-model.newrelativedatefilter.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newtotal.html
+++ b/vNext/docs/sdk-model.newtotal.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.newtwodimensional.html
+++ b/vNext/docs/sdk-model.newtwodimensional.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.objecttype.html
+++ b/vNext/docs/sdk-model.objecttype.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.objref.html
+++ b/vNext/docs/sdk-model.objref.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.objrefinscope.html
+++ b/vNext/docs/sdk-model.objrefinscope.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.popmeasurebuilder.builddefinition.html
+++ b/vNext/docs/sdk-model.popmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.popmeasurebuilder.generatelocalid.html
+++ b/vNext/docs/sdk-model.popmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.popmeasurebuilder.html
+++ b/vNext/docs/sdk-model.popmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.popmeasurebuilder.mastermeasure.html
+++ b/vNext/docs/sdk-model.popmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.popmeasurebuilder.popattribute.html
+++ b/vNext/docs/sdk-model.popmeasurebuilder.popattribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.popmeasurebuilderinput.html
+++ b/vNext/docs/sdk-model.popmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
+++ b/vNext/docs/sdk-model.previousperiodmeasurebuilder.builddefinition.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
+++ b/vNext/docs/sdk-model.previousperiodmeasurebuilder.datedatasets.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
+++ b/vNext/docs/sdk-model.previousperiodmeasurebuilder.generatelocalid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.previousperiodmeasurebuilder.html
+++ b/vNext/docs/sdk-model.previousperiodmeasurebuilder.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
+++ b/vNext/docs/sdk-model.previousperiodmeasurebuilder.mastermeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.previousperiodmeasurebuilderinput.html
+++ b/vNext/docs/sdk-model.previousperiodmeasurebuilderinput.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.rangeconditionoperator.html
+++ b/vNext/docs/sdk-model.rangeconditionoperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.rankingfilteroperator.html
+++ b/vNext/docs/sdk-model.rankingfilteroperator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.relativedatefiltervalues.html
+++ b/vNext/docs/sdk-model.relativedatefiltervalues.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.rgbtype.html
+++ b/vNext/docs/sdk-model.rgbtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.serializeobjref.html
+++ b/vNext/docs/sdk-model.serializeobjref.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.sortdirection.html
+++ b/vNext/docs/sdk-model.sortdirection.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.sortentityids.html
+++ b/vNext/docs/sdk-model.sortentityids.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.sortmeasurelocators.html
+++ b/vNext/docs/sdk-model.sortmeasurelocators.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.totalisnative.html
+++ b/vNext/docs/sdk-model.totalisnative.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.totaltype.html
+++ b/vNext/docs/sdk-model.totaltype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.uri.html
+++ b/vNext/docs/sdk-model.uri.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.uriref.html
+++ b/vNext/docs/sdk-model.uriref.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.userfullname.html
+++ b/vNext/docs/sdk-model.userfullname.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.visclassid.html
+++ b/vNext/docs/sdk-model.visclassid.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.visclassuri.html
+++ b/vNext/docs/sdk-model.visclassuri.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.visclassurl.html
+++ b/vNext/docs/sdk-model.visclassurl.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-model.visualizationproperties.html
+++ b/vNext/docs/sdk-model.visualizationproperties.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.areachart.html
+++ b/vNext/docs/sdk-ui-charts.areachart.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.axisnameposition.html
+++ b/vNext/docs/sdk-ui-charts.axisnameposition.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.barchart.html
+++ b/vNext/docs/sdk-ui-charts.barchart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.bubblechart.html
+++ b/vNext/docs/sdk-ui-charts.bubblechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.bulletchart.html
+++ b/vNext/docs/sdk-ui-charts.bulletchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.chartaligntypes.html
+++ b/vNext/docs/sdk-ui-charts.chartaligntypes.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.columnchart.html
+++ b/vNext/docs/sdk-ui-charts.columnchart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.combochart.html
+++ b/vNext/docs/sdk-ui-charts.combochart.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.donutchart.html
+++ b/vNext/docs/sdk-ui-charts.donutchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.funnelchart.html
+++ b/vNext/docs/sdk-ui-charts.funnelchart.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.headline.html
+++ b/vNext/docs/sdk-ui-charts.headline.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.heatmap.html
+++ b/vNext/docs/sdk-ui-charts.heatmap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.html
+++ b/vNext/docs/sdk-ui-charts.html
@@ -164,7 +164,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.stackby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.iareachartbucketprops.viewby.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iareachartprops.html
+++ b/vNext/docs/sdk-ui-charts.iareachartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.format.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.format.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.labelsenabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.max.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.max.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.measures.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.min.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.min.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.name.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.name.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.rotation.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.rotation.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisconfig.visible.html
+++ b/vNext/docs/sdk-ui-charts.iaxisconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisnameconfig.html
+++ b/vNext/docs/sdk-ui-charts.iaxisnameconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisnameconfig.position.html
+++ b/vNext/docs/sdk-ui-charts.iaxisnameconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iaxisnameconfig.visible.html
+++ b/vNext/docs/sdk-ui-charts.iaxisnameconfig.visible.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibarchartprops.html
+++ b/vNext/docs/sdk-ui-charts.ibarchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.size.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibubblechartprops.html
+++ b/vNext/docs/sdk-ui-charts.ibubblechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibucketchartprops.backend.html
+++ b/vNext/docs/sdk-ui-charts.ibucketchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibucketchartprops.html
+++ b/vNext/docs/sdk-ui-charts.ibucketchartprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibucketchartprops.workspace.html
+++ b/vNext/docs/sdk-ui-charts.ibucketchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.comparativemeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.targetmeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ibulletchartprops.html
+++ b/vNext/docs/sdk-ui-charts.ibulletchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartcallbacks.html
+++ b/vNext/docs/sdk-ui-charts.ichartcallbacks.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
+++ b/vNext/docs/sdk-ui-charts.ichartcallbacks.onlegendready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.colormapping.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.colormapping.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.colorpalette.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.colorpalette.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.colors.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.colors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.datalabels.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.datalabels.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.datapoints.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.datapoints.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.disabledrillunderline.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.dualaxis.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.dualaxis.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.enablechartsorting.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.enablechartsorting.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.enablecompactsize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.enablejoinedattributeaxisname.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.enablejoinedattributeaxisname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.forcedisabledrillonaxes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.grid.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.grid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.html
@@ -113,7 +113,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.legend.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.legend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.legendlayout.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.legendlayout.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.primarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.secondary_xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.secondary_yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.secondarycharttype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.separators.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.stackmeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.stackmeasurestopercent.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.xaxis.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.xaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.xformat.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.xformat.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.xlabel.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.xlabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.yaxis.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.yaxis.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.yformat.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.yformat.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.ylabel.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.ylabel.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartconfig.zoominsight.html
+++ b/vNext/docs/sdk-ui-charts.ichartconfig.zoominsight.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartlimits.categories.html
+++ b/vNext/docs/sdk-ui-charts.ichartlimits.categories.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartlimits.datapoints.html
+++ b/vNext/docs/sdk-ui-charts.ichartlimits.datapoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartlimits.html
+++ b/vNext/docs/sdk-ui-charts.ichartlimits.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ichartlimits.series.html
+++ b/vNext/docs/sdk-ui-charts.ichartlimits.series.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.stackby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icolumnchartprops.html
+++ b/vNext/docs/sdk-ui-charts.icolumnchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.primarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.secondarymeasures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.icombochartbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icombochartprops.html
+++ b/vNext/docs/sdk-ui-charts.icombochartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icommonchartprops.config.html
+++ b/vNext/docs/sdk-ui-charts.icommonchartprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icommonchartprops.execconfig.html
+++ b/vNext/docs/sdk-ui-charts.icommonchartprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icommonchartprops.height.html
+++ b/vNext/docs/sdk-ui-charts.icommonchartprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icommonchartprops.html
+++ b/vNext/docs/sdk-ui-charts.icommonchartprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.icommonchartprops.width.html
+++ b/vNext/docs/sdk-ui-charts.icommonchartprops.width.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idatalabelsconfig.html
+++ b/vNext/docs/sdk-ui-charts.idatalabelsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idatalabelsconfig.visible.html
+++ b/vNext/docs/sdk-ui-charts.idatalabelsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idatalabelsvisible.html
+++ b/vNext/docs/sdk-ui-charts.idatalabelsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idatapointsconfig.html
+++ b/vNext/docs/sdk-ui-charts.idatapointsconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idatapointsconfig.visible.html
+++ b/vNext/docs/sdk-ui-charts.idatapointsconfig.visible.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idatapointsvisible.html
+++ b/vNext/docs/sdk-ui-charts.idatapointsvisible.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.idonutchartprops.html
+++ b/vNext/docs/sdk-ui-charts.idonutchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ifunnelchartprops.html
+++ b/vNext/docs/sdk-ui-charts.ifunnelchartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.igridconfig.enabled.html
+++ b/vNext/docs/sdk-ui-charts.igridconfig.enabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.igridconfig.html
+++ b/vNext/docs/sdk-ui-charts.igridconfig.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.iheadlinebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheadlinebucketprops.html
+++ b/vNext/docs/sdk-ui-charts.iheadlinebucketprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.iheadlinebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
+++ b/vNext/docs/sdk-ui-charts.iheadlinebucketprops.primarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
+++ b/vNext/docs/sdk-ui-charts.iheadlinebucketprops.secondarymeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheadlineprops.html
+++ b/vNext/docs/sdk-ui-charts.iheadlineprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.columns.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iheatmapprops.html
+++ b/vNext/docs/sdk-ui-charts.iheatmapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegendconfig.enabled.html
+++ b/vNext/docs/sdk-ui-charts.ilegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegendconfig.html
+++ b/vNext/docs/sdk-ui-charts.ilegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegendconfig.position.html
+++ b/vNext/docs/sdk-ui-charts.ilegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegendconfig.responsive.html
+++ b/vNext/docs/sdk-ui-charts.ilegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegenddata.html
+++ b/vNext/docs/sdk-ui-charts.ilegenddata.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegenddata.legenditems.html
+++ b/vNext/docs/sdk-ui-charts.ilegenddata.legenditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegenditem.color.html
+++ b/vNext/docs/sdk-ui-charts.ilegenditem.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegenditem.html
+++ b/vNext/docs/sdk-ui-charts.ilegenditem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegenditem.name.html
+++ b/vNext/docs/sdk-ui-charts.ilegenditem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilegenditem.onclick.html
+++ b/vNext/docs/sdk-ui-charts.ilegenditem.onclick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartbucketprops.trendby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ilinechartprops.html
+++ b/vNext/docs/sdk-ui-charts.ilinechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartbucketprops.measures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartbucketprops.viewby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ipiechartprops.html
+++ b/vNext/docs/sdk-ui-charts.ipiechartprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.attribute.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.xaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotbucketprops.yaxismeasure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.iscatterplotprops.html
+++ b/vNext/docs/sdk-ui-charts.iscatterplotprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itooltipconfig.enabled.html
+++ b/vNext/docs/sdk-ui-charts.itooltipconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itooltipconfig.html
+++ b/vNext/docs/sdk-ui-charts.itooltipconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.itreemapbucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.itreemapbucketprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapbucketprops.measures.html
+++ b/vNext/docs/sdk-ui-charts.itreemapbucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.itreemapbucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
+++ b/vNext/docs/sdk-ui-charts.itreemapbucketprops.segmentby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
+++ b/vNext/docs/sdk-ui-charts.itreemapbucketprops.viewby.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.itreemapprops.html
+++ b/vNext/docs/sdk-ui-charts.itreemapprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
+++ b/vNext/docs/sdk-ui-charts.ixirrbucketprops.attribute.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ixirrbucketprops.filters.html
+++ b/vNext/docs/sdk-ui-charts.ixirrbucketprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ixirrbucketprops.html
+++ b/vNext/docs/sdk-ui-charts.ixirrbucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ixirrbucketprops.measure.html
+++ b/vNext/docs/sdk-ui-charts.ixirrbucketprops.measure.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-charts.ixirrbucketprops.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.ixirrprops.html
+++ b/vNext/docs/sdk-ui-charts.ixirrprops.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.linechart.html
+++ b/vNext/docs/sdk-ui-charts.linechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.onlegendready.html
+++ b/vNext/docs/sdk-ui-charts.onlegendready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.piechart.html
+++ b/vNext/docs/sdk-ui-charts.piechart.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.positiontype.html
+++ b/vNext/docs/sdk-ui-charts.positiontype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.scatterplot.html
+++ b/vNext/docs/sdk-ui-charts.scatterplot.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.treemap.html
+++ b/vNext/docs/sdk-ui-charts.treemap.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.viewbyattributeslimit.html
+++ b/vNext/docs/sdk-ui-charts.viewbyattributeslimit.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-charts.xirr.html
+++ b/vNext/docs/sdk-ui-charts.xirr.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.anydashboardeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.anydashboardeventhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.anyeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.anyeventhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.applyattributefilter.html
+++ b/vNext/docs/sdk-ui-dashboard.applyattributefilter.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.applydatefilter.html
+++ b/vNext/docs/sdk-ui-dashboard.applydatefilter.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.attributefilterselectiontype.html
+++ b/vNext/docs/sdk-ui-dashboard.attributefilterselectiontype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselection.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselection.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselection.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselection.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselection.type.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselection.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.elements.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.elements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.filterlocalid.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.filterlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.selectiontype.html
+++ b/vNext/docs/sdk-ui-dashboard.changeattributefilterselectionpayload.selectiontype.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changedatefilterselection.html
+++ b/vNext/docs/sdk-ui-dashboard.changedatefilterselection.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changedatefilterselection.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.changedatefilterselection.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changedatefilterselection.type.html
+++ b/vNext/docs/sdk-ui-dashboard.changedatefilterselection.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changefiltercontextselection.html
+++ b/vNext/docs/sdk-ui-dashboard.changefiltercontextselection.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changefiltercontextselection.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.changefiltercontextselection.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changefiltercontextselection.type.html
+++ b/vNext/docs/sdk-ui-dashboard.changefiltercontextselection.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changefiltercontextselectionpayload.filters.html
+++ b/vNext/docs/sdk-ui-dashboard.changefiltercontextselectionpayload.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changefiltercontextselectionpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.changefiltercontextselectionpayload.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.changefiltercontextselectionpayload.resetothers.html
+++ b/vNext/docs/sdk-ui-dashboard.changefiltercontextselectionpayload.resetothers.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.cleardatefilterselection.html
+++ b/vNext/docs/sdk-ui-dashboard.cleardatefilterselection.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.commandprocessingmeta.html
+++ b/vNext/docs/sdk-ui-dashboard.commandprocessingmeta.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.commandprocessingmeta.uuid.html
+++ b/vNext/docs/sdk-ui-dashboard.commandprocessingmeta.uuid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.customdashboardinsightcomponent.html
+++ b/vNext/docs/sdk-ui-dashboard.customdashboardinsightcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.customdashboardkpicomponent.html
+++ b/vNext/docs/sdk-ui-dashboard.customdashboardkpicomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.customdashboardwidgetcomponent.html
+++ b/vNext/docs/sdk-ui-dashboard.customdashboardwidgetcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchanged.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchanged.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchanged.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchanged.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchanged.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchangedpayload.filter.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchangedpayload.filter.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchangedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardattributefilterselectionchangedpayload.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardattributefiltertoattributefilter.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardattributefiltertoattributefilter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcommands.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcommands.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcommandtype.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcommandtype.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.allowunfinishedfeatures.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.allowunfinishedfeatures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.colorpalette.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.colorpalette.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.datefilterconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.datefilterconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.disabledefaultdrills.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.disabledefaultdrills.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.enablefiltervaluesresolutionindrillevents.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.enablefiltervaluesresolutionindrillevents.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.isembedded.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.isembedded.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.isexport.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.isexport.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.isreadonly.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.isreadonly.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.locale.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.mapboxtoken.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.mapboxtoken.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.menubuttonitemsvisibility.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.menubuttonitemsvisibility.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.objectavailability.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.objectavailability.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.separators.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardconfig.settings.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardconfig.settings.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.backend.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.clientid.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.clientid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.dashboardref.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.dashboardref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.dataproductid.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.dataproductid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.filtercontextref.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.filtercontextref.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcontext.workspace.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcontext.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcopysaved.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcopysaved.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcopysaved.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcopysaved.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcopysaved.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcopysaved.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcopysavedpayload.dashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcopysavedpayload.dashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardcopysavedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardcopysavedpayload.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchanged.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchanged.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchanged.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchanged.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchanged.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchangedpayload.datefilteroptionlocalid.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchangedpayload.datefilteroptionlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchangedpayload.filter.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchangedpayload.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchangedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefilterselectionchangedpayload.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefiltertodatefilterbydatedataset.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefiltertodatefilterbydatedataset.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddatefiltertodatefilterbywidget.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddatefiltertodatefilterbywidget.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddeinitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddeinitialized.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddeinitialized.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddeinitialized.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddeinitialized.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddeinitialized.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddeinitializedpayload.dashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddeinitializedpayload.dashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddeinitializedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddeinitializedpayload.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddescriptor.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddescriptor.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddispatch.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddispatch.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboarddrilldefinition.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboarddrilldefinition.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventbody.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventbody.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventevalfn.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventevalfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventhandler.eval.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventhandler.eval.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventhandler.handler.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventhandler.handler.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventhandler.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventhandlerfn.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventhandlerfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardevents.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardevents.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardeventtype.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardeventtype.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchanged.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchanged.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchanged.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchanged.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchanged.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchangedpayload.filtercontext.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchangedpayload.filtercontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchangedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardfiltercontextchangedpayload.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitialized.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitialized.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitialized.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitialized.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitialized.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.config.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.dashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.dashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.insights.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.insights.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.permissions.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardinitializedpayload.permissions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardmodelcustomizationfns.existingdashboardtransformfn.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardmodelcustomizationfns.existingdashboardtransformfn.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardmodelcustomizationfns.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardmodelcustomizationfns.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.author.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.author.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.debugname.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.debugname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.displayname.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.displayname.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.longdescription.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.longdescription.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.maxengineversion.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.maxengineversion.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.minengineversion.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.minengineversion.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.shortdescription.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.shortdescription.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.version.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardplugindescriptor.version.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1._pluginversion.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1._pluginversion.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.author.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.author.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.displayname.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.displayname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.maxengineversion.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.maxengineversion.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.minengineversion.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.minengineversion.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.register.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.register.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.version.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardpluginv1.version.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsaved.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsaved.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsaved.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsaved.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsaved.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsaved.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsavedpayload.dashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsavedpayload.dashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsavedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsavedpayload.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsavedpayload.newdashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsavedpayload.newdashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardselector.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardselector.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardselectorevaluator.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardselectorevaluator.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsharingchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsharingchanged.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsharingchanged.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsharingchanged.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsharingchanged.type.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsharingchanged.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsharingchangedpayload.dashboardref.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsharingchangedpayload.dashboardref.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsharingchangedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsharingchangedpayload.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardsharingchangedpayload.newsharingproperties.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardsharingchangedpayload.newsharingproperties.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstatechangecallback.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstatechangecallback.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor._constructor_.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.dispatch.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.dispatch.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.getdashboarddispatch.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.getdashboarddispatch.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.getdashboardselect.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.getdashboardselect.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.html
@@ -102,7 +102,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.isdashboardstoreaccessorinitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.isdashboardstoreaccessorinitialized.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.selectorevaluator.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.selectorevaluator.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.setselectanddispatch.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessor.setselectanddispatch.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.clearaccessorfordashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.clearaccessorfordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.clearallaccessors.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.clearallaccessors.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getaccessorsfordashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getaccessorsfordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getdashboarddispatchfordashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getdashboarddispatchfordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getdashboardselectfordashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getdashboardselectfordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getonchangehandlerfordashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.getonchangehandlerfordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.html
@@ -115,7 +115,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.isaccessorinitializedfordashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardstoreaccessorrepository.isaccessorinitializedfordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.dashboardtransformfn.html
+++ b/vNext/docs/sdk-ui-dashboard.dashboardtransformfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterconfigvalidationresult.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterconfigvalidationresult.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterselection.datefilteroptionlocalid.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterselection.datefilteroptionlocalid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterselection.from.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterselection.from.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterselection.granularity.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterselection.granularity.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterselection.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterselection.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterselection.to.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterselection.to.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefilterselection.type.html
+++ b/vNext/docs/sdk-ui-dashboard.datefilterselection.type.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailed.html
+++ b/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailed.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailed.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailed.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailed.type.html
+++ b/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailed.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailedpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailedpayload.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailedpayload.result.html
+++ b/vNext/docs/sdk-ui-dashboard.datefiltervalidationfailedpayload.result.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.datefiltervalidationresult.html
+++ b/vNext/docs/sdk-ui-dashboard.datefiltervalidationresult.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.defaultdashboardinsight.html
+++ b/vNext/docs/sdk-ui-dashboard.defaultdashboardinsight.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.defaultdashboardkpi.html
+++ b/vNext/docs/sdk-ui-dashboard.defaultdashboardkpi.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.defaultdashboardthememodifier.html
+++ b/vNext/docs/sdk-ui-dashboard.defaultdashboardthememodifier.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.extendeddashboarditem.html
+++ b/vNext/docs/sdk-ui-dashboard.extendeddashboarditem.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.extendeddashboarditemtype.html
+++ b/vNext/docs/sdk-ui-dashboard.extendeddashboarditemtype.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.extendeddashboarditemtypes.html
+++ b/vNext/docs/sdk-ui-dashboard.extendeddashboarditemtypes.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.extendeddashboardlayoutsection.html
+++ b/vNext/docs/sdk-ui-dashboard.extendeddashboardlayoutsection.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.extendeddashboardwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.extendeddashboardwidget.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.filterbarrenderingmode.html
+++ b/vNext/docs/sdk-ui-dashboard.filterbarrenderingmode.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.filtercontextitemstodashboardfiltersbydatedataset.html
+++ b/vNext/docs/sdk-ui-dashboard.filtercontextitemstodashboardfiltersbydatedataset.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.filtercontextitemstodashboardfiltersbywidget.html
+++ b/vNext/docs/sdk-ui-dashboard.filtercontextitemstodashboardfiltersbywidget.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.filtercontexttodashboardfiltersbydatedataset.html
+++ b/vNext/docs/sdk-ui-dashboard.filtercontexttodashboardfiltersbydatedataset.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.filtercontexttodashboardfiltersbywidget.html
+++ b/vNext/docs/sdk-ui-dashboard.filtercontexttodashboardfiltersbywidget.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.fluidlayoutcustomizationfn.html
+++ b/vNext/docs/sdk-ui-dashboard.fluidlayoutcustomizationfn.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.html
@@ -327,7 +327,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.ctx.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.ctx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.meta.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.meta.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.payload.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.type.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomdashboardevent.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomwidget.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomwidgetbase.customtype.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomwidgetbase.customtype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomwidgetbase.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomwidgetbase.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomwidgetbase.type.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomwidgetbase.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.icustomwidgetdefinition.html
+++ b/vNext/docs/sdk-ui-dashboard.icustomwidgetdefinition.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.backend.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.config.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.config.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.dashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.dashboard.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.filtercontextref.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.filtercontextref.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.permissions.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.permissions.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.workspace.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardbaseprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcommand.correlationid.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcommand.correlationid.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcommand.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcommand.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcommand.meta.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcommand.meta.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcommand.type.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcommand.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.insightcomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.insightcomponentprovider.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.kpicomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.kpicomponentprovider.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.widgetcomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomcomponentprops.widgetcomponentprovider.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizationprops.customizationfns.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizationprops.customizationfns.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizationprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizationprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.customwidgets.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.customwidgets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.filterbar.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.filterbar.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.insightwidgets.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.insightwidgets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.kpiwidgets.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.kpiwidgets.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.layout.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardcustomizer.layout.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboarddrillevent.drilldefinitions.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboarddrillevent.drilldefinitions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboarddrillevent.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboarddrillevent.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboarddrillevent.widgetref.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboarddrillevent.widgetref.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardengine.getdashboardcomponent.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardengine.getdashboardcomponent.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardengine.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardengine.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardengine.initializeplugins.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardengine.initializeplugins.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardengine.version.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardengine.version.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardevent.correlationid.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardevent.correlationid.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardevent.ctx.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardevent.ctx.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardevent.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardevent.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardevent.meta.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardevent.meta.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardevent.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardevent.payload.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardevent.type.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardevent.type.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.addcustomeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.addcustomeventhandler.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.addeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.addeventhandler.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.removecustomeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.removecustomeventhandler.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.removeeventhandler.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.removeeventhandler.html
@@ -35,7 +35,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.subscribetostatechanges.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.subscribetostatechanges.html
@@ -35,7 +35,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.unsubscribefromstatechanges.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventhandling.unsubscribefromstatechanges.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventing.eventhandlers.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventing.eventhandlers.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventing.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventing.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventing.oneventinginitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventing.oneventinginitialized.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardeventing.onstatechange.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardeventing.onstatechange.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardextensionprops.additionalreduxcontext.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardextensionprops.additionalreduxcontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardextensionprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardextensionprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardfilter.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardfilter.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomdecorator.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomdecorator.html
@@ -55,7 +55,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withcustomprovider.html
@@ -38,7 +38,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withtag.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightcustomizer.withtag.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightprops.insight.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightprops.insight.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardinsightprops.widget.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardinsightprops.widget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpicustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpicustomizer.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomdecorator.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomdecorator.html
@@ -55,7 +55,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpicustomizer.withcustomprovider.html
@@ -36,7 +36,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.alert.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.alert.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.filters.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.filters.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.kpiwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardkpiprops.kpiwidget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.customizefluidlayout.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.customizefluidlayout.html
@@ -37,7 +37,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardlayoutcustomizer.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1._pluginversion.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1._pluginversion.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginloaded.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginloaded.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginunload.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.onpluginunload.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.register.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardplugincontract_v1.register.html
@@ -39,7 +39,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardprops.children.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardprops.children.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.disablethemeloading.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.disablethemeloading.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.theme.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.theme.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.thememodifier.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardthemingprops.thememodifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.addcustomwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.addcustomwidget.html
@@ -32,7 +32,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardwidgetcustomizer.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.datedataset.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.datedataset.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.ignoredattributefilters.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.ignoredattributefilters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.widget.html
+++ b/vNext/docs/sdk-ui-dashboard.idashboardwidgetprops.widget.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.html
+++ b/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.origin.html
+++ b/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.origin.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.target.html
+++ b/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.target.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.type.html
+++ b/vNext/docs/sdk-ui-dashboard.idrilldowndefinition.type.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.ifilterbarcustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.ifilterbarcustomizer.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.ifilterbarcustomizer.setrenderingmode.html
+++ b/vNext/docs/sdk-ui-dashboard.ifilterbarcustomizer.setrenderingmode.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.additem.html
+++ b/vNext/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.additem.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.addsection.html
+++ b/vNext/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.addsection.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.html
+++ b/vNext/docs/sdk-ui-dashboard.ifluidlayoutcustomizer.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initializedashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.initializedashboard.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initializedashboard.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.initializedashboard.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initializedashboard.type.html
+++ b/vNext/docs/sdk-ui-dashboard.initializedashboard.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initializedashboardpayload.config.html
+++ b/vNext/docs/sdk-ui-dashboard.initializedashboardpayload.config.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initializedashboardpayload.html
+++ b/vNext/docs/sdk-ui-dashboard.initializedashboardpayload.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initializedashboardpayload.permissions.html
+++ b/vNext/docs/sdk-ui-dashboard.initializedashboardpayload.permissions.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.initialloadcorrelationid.html
+++ b/vNext/docs/sdk-ui-dashboard.initialloadcorrelationid.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.insightcomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.insightcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iscustomdashboardevent.html
+++ b/vNext/docs/sdk-ui-dashboard.iscustomdashboardevent.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iscustomwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.iscustomwidget.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iscustomwidgetdefinition.html
+++ b/vNext/docs/sdk-ui-dashboard.iscustomwidgetdefinition.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardattributefilterselectionchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardattributefilterselectionchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardcopysaved.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardcopysaved.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboarddatefilterselectionchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboarddatefilterselectionchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboarddeinitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboarddeinitialized.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardevent.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardevent.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardeventorcustomdashboardevent.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardeventorcustomdashboardevent.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardfiltercontextchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardfiltercontextchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardinitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardinitialized.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardsaved.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardsaved.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdashboardsharingchanged.html
+++ b/vNext/docs/sdk-ui-dashboard.isdashboardsharingchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isdrilldowndefinition.html
+++ b/vNext/docs/sdk-ui-dashboard.isdrilldowndefinition.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isharingproperties.granteestoadd.html
+++ b/vNext/docs/sdk-ui-dashboard.isharingproperties.granteestoadd.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isharingproperties.granteestodelete.html
+++ b/vNext/docs/sdk-ui-dashboard.isharingproperties.granteestodelete.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isharingproperties.html
+++ b/vNext/docs/sdk-ui-dashboard.isharingproperties.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isharingproperties.islocked.html
+++ b/vNext/docs/sdk-ui-dashboard.isharingproperties.islocked.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isharingproperties.isunderstrictcontrol.html
+++ b/vNext/docs/sdk-ui-dashboard.isharingproperties.isunderstrictcontrol.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.isharingproperties.sharestatus.html
+++ b/vNext/docs/sdk-ui-dashboard.isharingproperties.sharestatus.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iusecustomwidgetexecutiondataviewconfig.execution.html
+++ b/vNext/docs/sdk-ui-dashboard.iusecustomwidgetexecutiondataviewconfig.execution.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iusecustomwidgetexecutiondataviewconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.iusecustomwidgetexecutiondataviewconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iusecustomwidgetexecutiondataviewconfig.widget.html
+++ b/vNext/docs/sdk-ui-dashboard.iusecustomwidgetexecutiondataviewconfig.widget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iusecustomwidgetinsightdataviewconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.iusecustomwidgetinsightdataviewconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iusecustomwidgetinsightdataviewconfig.insight.html
+++ b/vNext/docs/sdk-ui-dashboard.iusecustomwidgetinsightdataviewconfig.insight.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iusecustomwidgetinsightdataviewconfig.widget.html
+++ b/vNext/docs/sdk-ui-dashboard.iusecustomwidgetinsightdataviewconfig.widget.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iuseinsightwidgetdataview.html
+++ b/vNext/docs/sdk-ui-dashboard.iuseinsightwidgetdataview.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.iuseinsightwidgetdataview.insightwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.iuseinsightwidgetdataview.insightwidget.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.kpicomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.kpicomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.newcustomwidget.html
+++ b/vNext/docs/sdk-ui-dashboard.newcustomwidget.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.newdashboardengine.html
+++ b/vNext/docs/sdk-ui-dashboard.newdashboardengine.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.newdashboarditem.html
+++ b/vNext/docs/sdk-ui-dashboard.newdashboarditem.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.newdashboardsection.html
+++ b/vNext/docs/sdk-ui-dashboard.newdashboardsection.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.objectavailabilityconfig.excludeobjectswithtags.html
+++ b/vNext/docs/sdk-ui-dashboard.objectavailabilityconfig.excludeobjectswithtags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.objectavailabilityconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.objectavailabilityconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.objectavailabilityconfig.includeobjectswithtags.html
+++ b/vNext/docs/sdk-ui-dashboard.objectavailabilityconfig.includeobjectswithtags.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.onfireddashboarddrillevent.html
+++ b/vNext/docs/sdk-ui-dashboard.onfireddashboarddrillevent.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.optionalinsightcomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.optionalinsightcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.optionalkpicomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.optionalkpicomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.optionalprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.optionalprovider.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.optionalwidgetcomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.optionalwidgetcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.resetattributefilterselection.html
+++ b/vNext/docs/sdk-ui-dashboard.resetattributefilterselection.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.resolveddashboardconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.resolveddashboardconfig.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardas.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardas.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardas.payload.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardas.payload.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardas.type.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardas.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.switchtocopy.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.switchtocopy.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.title.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.useoriginalfiltercontext.html
+++ b/vNext/docs/sdk-ui-dashboard.savedashboardaspayload.useoriginalfiltercontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectbackendcapabilities.html
+++ b/vNext/docs/sdk-ui-dashboard.selectbackendcapabilities.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcancreateanalyticaldashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcancreateanalyticaldashboard.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcancreatescheduledmail.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcancreatescheduledmail.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcancreatevisualization.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcancreatevisualization.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanexecuteraw.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanexecuteraw.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanexportreport.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanexportreport.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcaninitdata.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcaninitdata.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcaninviteusertoworkspace.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcaninviteusertoworkspace.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanlistusersinworkspace.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanlistusersinworkspace.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanmanageacl.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanmanageacl.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanmanageanalyticaldashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanmanageanalyticaldashboard.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanmanagedomain.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanmanagedomain.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanmanagemetric.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanmanagemetric.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanmanageworkspace.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanmanageworkspace.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanrefreshdata.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanrefreshdata.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcanuploadnonproductioncsv.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcanuploadnonproductioncsv.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcatalogattributedisplayforms.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcatalogattributedisplayforms.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcatalogattributes.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcatalogattributes.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcatalogdatedatasets.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcatalogdatedatasets.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcatalogfacts.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcatalogfacts.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcatalogmeasures.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcatalogmeasures.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcolorpalette.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcolorpalette.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.selectconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcurrentuser.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcurrentuser.html
@@ -108,7 +108,8 @@ customize.customWidgets().addCustomWidget(<span class="hljs-string">"greetingsWi
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectcurrentuserref.html
+++ b/vNext/docs/sdk-ui-dashboard.selectcurrentuserref.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboarddescription.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboarddescription.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboardid.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboardid.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboardidref.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboardidref.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboardref.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboardref.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboardtags.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboardtags.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboardtitle.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboardtitle.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboarduri.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboarduri.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdashboarduriref.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdashboarduriref.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdatefilterconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdatefilterconfig.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdateformat.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdateformat.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectdisabledefaultdrills.html
+++ b/vNext/docs/sdk-ui-dashboard.selectdisabledefaultdrills.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenableclickableattributeurl.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenableclickableattributeurl.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablecompanylogoinembeddedui.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablecompanylogoinembeddedui.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablefiltervaluesresolutionindrillevents.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablefiltervaluesresolutionindrillevents.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltodashboard.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltodashboard.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltoinsight.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltoinsight.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltourl.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboarddrilltourl.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardexportpdf.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardexportpdf.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardimplicitdrilldown.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardimplicitdrilldown.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardsaveasnew.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardsaveasnew.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardschedule.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardschedule.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardschedulerecipients.html
+++ b/vNext/docs/sdk-ui-dashboard.selectenablekpidashboardschedulerecipients.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selecthidekpidrillinembedded.html
+++ b/vNext/docs/sdk-ui-dashboard.selecthidekpidrillinembedded.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectinsights.html
+++ b/vNext/docs/sdk-ui-dashboard.selectinsights.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectisdashboardsaving.html
+++ b/vNext/docs/sdk-ui-dashboard.selectisdashboardsaving.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectisembedded.html
+++ b/vNext/docs/sdk-ui-dashboard.selectisembedded.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectisreadonly.html
+++ b/vNext/docs/sdk-ui-dashboard.selectisreadonly.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectlocale.html
+++ b/vNext/docs/sdk-ui-dashboard.selectlocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectobjectavailabilityconfig.html
+++ b/vNext/docs/sdk-ui-dashboard.selectobjectavailabilityconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectpermissions.html
+++ b/vNext/docs/sdk-ui-dashboard.selectpermissions.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectplatformedition.html
+++ b/vNext/docs/sdk-ui-dashboard.selectplatformedition.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectseparators.html
+++ b/vNext/docs/sdk-ui-dashboard.selectseparators.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.selectsettings.html
+++ b/vNext/docs/sdk-ui-dashboard.selectsettings.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.clearaccessor.html
+++ b/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.clearaccessor.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.getdashboarddispatch.html
+++ b/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.getdashboarddispatch.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.getdashboardselect.html
+++ b/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.getdashboardselect.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.getonchangehandler.html
+++ b/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.getonchangehandler.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.html
+++ b/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.isaccessorinitialized.html
+++ b/vNext/docs/sdk-ui-dashboard.singledashboardstoreaccessor.isaccessorinitialized.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.singleeventtypehandler.html
+++ b/vNext/docs/sdk-ui-dashboard.singleeventtypehandler.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.usecustomwidgetexecutiondataview.html
+++ b/vNext/docs/sdk-ui-dashboard.usecustomwidgetexecutiondataview.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.usecustomwidgetinsightdataview.html
+++ b/vNext/docs/sdk-ui-dashboard.usecustomwidgetinsightdataview.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.usedashboardselector.html
+++ b/vNext/docs/sdk-ui-dashboard.usedashboardselector.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.usedispatchdashboardcommand.html
+++ b/vNext/docs/sdk-ui-dashboard.usedispatchdashboardcommand.html
@@ -85,7 +85,8 @@ const resetAttributeFilter = use<span class="hljs-constructor">DispatchDashboard
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.useinsightwidgetdataview.html
+++ b/vNext/docs/sdk-ui-dashboard.useinsightwidgetdataview.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.usewidgetfilters.html
+++ b/vNext/docs/sdk-ui-dashboard.usewidgetfilters.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-dashboard.widgetcomponentprovider.html
+++ b/vNext/docs/sdk-ui-dashboard.widgetcomponentprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.absolutedatefilteroption.html
+++ b/vNext/docs/sdk-ui-filters.absolutedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.attributeelements.html
+++ b/vNext/docs/sdk-ui-filters.attributeelements.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.attributefilter.html
+++ b/vNext/docs/sdk-ui-filters.attributefilter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.attributefilterbutton.html
+++ b/vNext/docs/sdk-ui-filters.attributefilterbutton.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.attributelistitem.html
+++ b/vNext/docs/sdk-ui-filters.attributelistitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilter._constructor_.html
+++ b/vNext/docs/sdk-ui-filters.datefilter._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilter.componentdidmount.html
+++ b/vNext/docs/sdk-ui-filters.datefilter.componentdidmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilter.defaultprops.html
+++ b/vNext/docs/sdk-ui-filters.datefilter.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
+++ b/vNext/docs/sdk-ui-filters.datefilter.getderivedstatefromprops.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilter.html
+++ b/vNext/docs/sdk-ui-filters.datefilter.html
@@ -105,7 +105,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilter.render.html
+++ b/vNext/docs/sdk-ui-filters.datefilter.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilterhelpers.html
+++ b/vNext/docs/sdk-ui-filters.datefilterhelpers.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilteroption.html
+++ b/vNext/docs/sdk-ui-filters.datefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
+++ b/vNext/docs/sdk-ui-filters.datefilterrelativeoptiongroup.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.defaultdatefilteroptions.html
+++ b/vNext/docs/sdk-ui-filters.defaultdatefilteroptions.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.emptylistitem.empty.html
+++ b/vNext/docs/sdk-ui-filters.emptylistitem.empty.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.emptylistitem.html
+++ b/vNext/docs/sdk-ui-filters.emptylistitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
+++ b/vNext/docs/sdk-ui-filters.filtervisibledatefilteroptions.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.granularityintlkey.html
+++ b/vNext/docs/sdk-ui-filters.granularityintlkey.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.html
+++ b/vNext/docs/sdk-ui-filters.html
@@ -168,7 +168,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.attributefilterref.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.attributefilterref.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.deletefilter.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.deletefilter.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.iselementsloading.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.iselementsloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.isloaded.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.isloaded.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.ismobile.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.ismobile.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.listitemclass.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.listitemclass.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.maxselectionsize.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.maxselectionsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.onconfigurationchange.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.onconfigurationchange.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showconfigurationbutton.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showconfigurationbutton.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showdeletebutton.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.showdeletebutton.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.width.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyextendedprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.applydisabled.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.applydisabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.error.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.error.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.isfullwidth.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.isfullwidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.isinverted.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.isinverted.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.isloading.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.items.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onapplybuttonclicked.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onapplybuttonclicked.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onclosebuttonclicked.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onclosebuttonclicked.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onrangechange.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onrangechange.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onsearch.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onsearch.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onselect.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.onselect.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.parentfiltertitles.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.parentfiltertitles.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.searchstring.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.searchstring.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.selecteditems.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.selecteditems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.showitemsfilteredmessage.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.showitemsfilteredmessage.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.totalcount.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownbodyprops.totalcount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownitem.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownitem.ref.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownitem.title.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownitem.type.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownitem.type.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.isloading.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseout.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseout.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseover.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.onmouseover.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.ononly.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.ononly.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.onselect.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.onselect.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.selected.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.selected.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.source.html
+++ b/vNext/docs/sdk-ui-filters.iattributedropdownlistitemprops.source.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementschildren.error.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementschildren.error.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementschildren.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementschildren.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementschildren.isloading.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementschildren.loadmore.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementschildren.validelements.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.backend.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.children.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.children.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.displayform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.filters.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.limit.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.limit.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.offset.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.offset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.options.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.options.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
+++ b/vNext/docs/sdk-ui-filters.iattributeelementsprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.filter.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilteroverattribute.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.renderbody.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.renderbody.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonownprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterbuttonprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterbuttonprops.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.backend.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.connecttoplaceholder.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.filter.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.filter.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.filtererror.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.filterloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.fullscreenonmobile.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.identifier.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.identifier.html
@@ -26,7 +26,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.locale.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.onapply.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.onapply.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.onerror.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.parentfilteroverattribute.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.parentfilters.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.title.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.title.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.titlewithselection.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iattributefilterprops.workspace.html
+++ b/vNext/docs/sdk-ui-filters.iattributefilterprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.icustomgranularityselection.enable.html
+++ b/vNext/docs/sdk-ui-filters.icustomgranularityselection.enable.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.icustomgranularityselection.html
+++ b/vNext/docs/sdk-ui-filters.icustomgranularityselection.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
+++ b/vNext/docs/sdk-ui-filters.icustomgranularityselection.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idateandmessagetranslator.html
+++ b/vNext/docs/sdk-ui-filters.idateandmessagetranslator.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.html
+++ b/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
+++ b/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.onapply.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
+++ b/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.oncancel.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
+++ b/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.onclose.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
+++ b/vNext/docs/sdk-ui-filters.idatefiltercallbackprops.onopen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
+++ b/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.absoluteform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
+++ b/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.absolutepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
+++ b/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.alltime.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.html
+++ b/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
+++ b/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.relativeform.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
+++ b/vNext/docs/sdk-ui-filters.idatefilteroptionsbytype.relativepreset.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.availablegranularities.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.customfiltername.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.datefiltermode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.dateformat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.filteroptions.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.iseditmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterownprops.locale.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterownprops.locale.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterprops.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterprops.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstate.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstate.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstate.initexcludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstate.initselectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstate.isexcludecurrentperiodenabled.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstatepropsintersection.excludecurrentperiod.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstatepropsintersection.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
+++ b/vNext/docs/sdk-ui-filters.idatefilterstatepropsintersection.selectedfilteroption.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatetranslator.formatdate.html
+++ b/vNext/docs/sdk-ui-filters.idatetranslator.formatdate.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.idatetranslator.html
+++ b/vNext/docs/sdk-ui-filters.idatetranslator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
+++ b/vNext/docs/sdk-ui-filters.iextendeddatefiltererrors.absoluteform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iextendeddatefiltererrors.html
+++ b/vNext/docs/sdk-ui-filters.iextendeddatefiltererrors.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
+++ b/vNext/docs/sdk-ui-filters.iextendeddatefiltererrors.relativeform.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasuredropdownitem.html
+++ b/vNext/docs/sdk-ui-filters.imeasuredropdownitem.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
+++ b/vNext/docs/sdk-ui-filters.imeasuredropdownitem.ref.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
+++ b/vNext/docs/sdk-ui-filters.imeasuredropdownitem.sequencenumber.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasuredropdownitem.title.html
+++ b/vNext/docs/sdk-ui-filters.imeasuredropdownitem.title.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.displaytreatnullaszerooption.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.enableoperatorselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.measureidentifier.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.separators.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.treatnullaszerodefaultvalue.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.usepercentage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefiltercommonprops.warningmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterprops.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterstate.displaydropdown.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imeasurevaluefilterstate.html
+++ b/vNext/docs/sdk-ui-filters.imeasurevaluefilterstate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imessagetranslator.formatmessage.html
+++ b/vNext/docs/sdk-ui-filters.imessagetranslator.formatmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.imessagetranslator.html
+++ b/vNext/docs/sdk-ui-filters.imessagetranslator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.anchorel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.enablerenamingmeasuretometric.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.enablerenamingmeasuretometric.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterdropdownprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.attributeitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.buttontitle.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.customgranularityselection.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.enablerenamingmeasuretometric.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.enablerenamingmeasuretometric.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.filter.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.filter.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.locale.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.locale.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.measureitems.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.onapply.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.onapply.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.oncancel.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseout.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
+++ b/vNext/docs/sdk-ui-filters.irankingfilterprops.ondropdownitemmouseover.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.isabsolutedatefilteroption.html
+++ b/vNext/docs/sdk-ui-filters.isabsolutedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.isemptylistitem.html
+++ b/vNext/docs/sdk-ui-filters.isemptylistitem.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.isnonemptylistitem.html
+++ b/vNext/docs/sdk-ui-filters.isnonemptylistitem.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.isrelativedatefilteroption.html
+++ b/vNext/docs/sdk-ui-filters.isrelativedatefilteroption.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.isuirelativedatefilterform.html
+++ b/vNext/docs/sdk-ui-filters.isuirelativedatefilterform.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
+++ b/vNext/docs/sdk-ui-filters.iuiabsolutedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
+++ b/vNext/docs/sdk-ui-filters.iuiabsolutedatefilterform.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
+++ b/vNext/docs/sdk-ui-filters.iuiabsolutedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
+++ b/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.from.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
+++ b/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.granularity.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.html
+++ b/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
+++ b/vNext/docs/sdk-ui-filters.iuirelativedatefilterform.to.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.iwarningmessage.html
+++ b/vNext/docs/sdk-ui-filters.iwarningmessage.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilter.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilter.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilter.html
@@ -97,7 +97,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilter.render.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilter.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilter.state.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilter.state.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilterdropdown.defaultprops.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilterdropdown.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilterdropdown.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
+++ b/vNext/docs/sdk-ui-filters.measurevaluefilterdropdown.render.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.rankingfilter.html
+++ b/vNext/docs/sdk-ui-filters.rankingfilter.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.rankingfilterdropdown.html
+++ b/vNext/docs/sdk-ui-filters.rankingfilterdropdown.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.relativedatefilteroption.html
+++ b/vNext/docs/sdk-ui-filters.relativedatefilteroption.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-filters.warningmessage.html
+++ b/vNext/docs/sdk-ui-filters.warningmessage.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.centerpositionchangedcallback.html
+++ b/vNext/docs/sdk-ui-geo.centerpositionchangedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.geopushpinchart.html
+++ b/vNext/docs/sdk-ui-geo.geopushpinchart.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.html
+++ b/vNext/docs/sdk-ui-geo.html
@@ -115,7 +115,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoattributeitem.data.html
+++ b/vNext/docs/sdk-ui-geo.igeoattributeitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoattributeitem.html
+++ b/vNext/docs/sdk-ui-geo.igeoattributeitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.center.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.center.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.colormapping.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.colormapping.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.colorpalette.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.colorpalette.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.colors.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.colors.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.cooperativegestures.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.cooperativegestures.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.isexportmode.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.isexportmode.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.legend.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.legend.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.limit.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.limit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.mapboxtoken.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.points.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.selectedsegmentitems.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.separators.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.separators.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.showlabels.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.showlabels.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.viewport.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.viewport.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfig.zoom.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfig.zoom.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfigviewport.area.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfigviewport.area.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfigviewport.frozen.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfigviewport.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfigviewport.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeoconfigviewportarea.html
+++ b/vNext/docs/sdk-ui-geo.igeoconfigviewportarea.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodata.color.html
+++ b/vNext/docs/sdk-ui-geo.igeodata.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodata.html
+++ b/vNext/docs/sdk-ui-geo.igeodata.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodata.location.html
+++ b/vNext/docs/sdk-ui-geo.igeodata.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodata.segment.html
+++ b/vNext/docs/sdk-ui-geo.igeodata.segment.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodata.size.html
+++ b/vNext/docs/sdk-ui-geo.igeodata.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodata.tooltiptext.html
+++ b/vNext/docs/sdk-ui-geo.igeodata.tooltiptext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodataitem.html
+++ b/vNext/docs/sdk-ui-geo.igeodataitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodataitem.index.html
+++ b/vNext/docs/sdk-ui-geo.igeodataitem.index.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeodataitem.name.html
+++ b/vNext/docs/sdk-ui-geo.igeodataitem.name.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolegendconfig.enabled.html
+++ b/vNext/docs/sdk-ui-geo.igeolegendconfig.enabled.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolegendconfig.html
+++ b/vNext/docs/sdk-ui-geo.igeolegendconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolegendconfig.position.html
+++ b/vNext/docs/sdk-ui-geo.igeolegendconfig.position.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolegendconfig.responsive.html
+++ b/vNext/docs/sdk-ui-geo.igeolegendconfig.responsive.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolnglat.html
+++ b/vNext/docs/sdk-ui-geo.igeolnglat.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolnglat.lat.html
+++ b/vNext/docs/sdk-ui-geo.igeolnglat.lat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolnglat.lng.html
+++ b/vNext/docs/sdk-ui-geo.igeolnglat.lng.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolocationitem.data.html
+++ b/vNext/docs/sdk-ui-geo.igeolocationitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeolocationitem.html
+++ b/vNext/docs/sdk-ui-geo.igeolocationitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeomeasureitem.data.html
+++ b/vNext/docs/sdk-ui-geo.igeomeasureitem.data.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeomeasureitem.format.html
+++ b/vNext/docs/sdk-ui-geo.igeomeasureitem.format.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeomeasureitem.html
+++ b/vNext/docs/sdk-ui-geo.igeomeasureitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
+++ b/vNext/docs/sdk-ui-geo.igeopointsconfig.groupnearbypoints.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopointsconfig.html
+++ b/vNext/docs/sdk-ui-geo.igeopointsconfig.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
+++ b/vNext/docs/sdk-ui-geo.igeopointsconfig.maxsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopointsconfig.minsize.html
+++ b/vNext/docs/sdk-ui-geo.igeopointsconfig.minsize.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.color.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.config.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.config.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.execconfig.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.filters.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.location.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.location.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.oncenterpositionchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.onzoomchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.segmentby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.size.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.size.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.sortby.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
+++ b/vNext/docs/sdk-ui-geo.igeopushpinchartprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeosegmentitem.html
+++ b/vNext/docs/sdk-ui-geo.igeosegmentitem.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.igeosegmentitem.uris.html
+++ b/vNext/docs/sdk-ui-geo.igeosegmentitem.uris.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.pushpinsizeoption.html
+++ b/vNext/docs/sdk-ui-geo.pushpinsizeoption.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-geo.zoomchangedcallback.html
+++ b/vNext/docs/sdk-ui-geo.zoomchangedcallback.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.adaptiveloadoptions.html
+++ b/vNext/docs/sdk-ui-loaders.adaptiveloadoptions.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.adaptive.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.adaptive.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.fordashboard.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.fordashboard.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.fromclientworkspace.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.fromclientworkspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.fromworkspace.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.fromworkspace.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.html
@@ -103,7 +103,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.load.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.load.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.onbackend.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.onbackend.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.staticonly.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.staticonly.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.withbaseprops.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.withbaseprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.withembeddedplugins.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.withembeddedplugins.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloader.withfiltercontext.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloader.withfiltercontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloadresult.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloadresult.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardloadstatus.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardloadstatus.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.dashboardstub.html
+++ b/vNext/docs/sdk-ui-loaders.dashboardstub.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.html
+++ b/vNext/docs/sdk-ui-loaders.html
@@ -126,7 +126,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardbasepropsforloader.dashboard.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardbasepropsforloader.dashboard.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardbasepropsforloader.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardbasepropsforloader.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.fordashboard.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.fordashboard.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.fromclientworkspace.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.fromclientworkspace.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.fromworkspace.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.fromworkspace.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.load.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.load.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.onbackend.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.onbackend.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.withbaseprops.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.withbaseprops.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.withembeddedplugins.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.withembeddedplugins.html
@@ -35,7 +35,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloader.withfiltercontext.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloader.withfiltercontext.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloadoptions.adaptiveloadoptions.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloadoptions.adaptiveloadoptions.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloadoptions.allowunfinishedfeatures.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloadoptions.allowunfinishedfeatures.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloadoptions.clientworkspace.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloadoptions.clientworkspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloadoptions.extraplugins.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloadoptions.extraplugins.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloadoptions.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloadoptions.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardloadoptions.loadingmode.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardloadoptions.loadingmode.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardstubprops.errorcomponent.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardstubprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardstubprops.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardstubprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.idashboardstubprops.loadingcomponent.html
+++ b/vNext/docs/sdk-ui-loaders.idashboardstubprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.iembeddedplugin.factory.html
+++ b/vNext/docs/sdk-ui-loaders.iembeddedplugin.factory.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.iembeddedplugin.html
+++ b/vNext/docs/sdk-ui-loaders.iembeddedplugin.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.iembeddedplugin.parameters.html
+++ b/vNext/docs/sdk-ui-loaders.iembeddedplugin.parameters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.modulefederationintegration.html
+++ b/vNext/docs/sdk-ui-loaders.modulefederationintegration.html
@@ -115,7 +115,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-loaders.usedashboardloader.html
+++ b/vNext/docs/sdk-ui-loaders.usedashboardloader.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.columnlocator.html
+++ b/vNext/docs/sdk-ui-pivot.columnlocator.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.columnresizedcallback.html
+++ b/vNext/docs/sdk-ui-pivot.columnresizedcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.columnwidth.html
+++ b/vNext/docs/sdk-ui-pivot.columnwidth.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.columnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.columnwidthitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.defaultcolumnwidth.html
+++ b/vNext/docs/sdk-ui-pivot.defaultcolumnwidth.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.html
+++ b/vNext/docs/sdk-ui-pivot.html
@@ -139,7 +139,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
+++ b/vNext/docs/sdk-ui-pivot.iabsolutecolumnwidth.allowgrowtofit.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
+++ b/vNext/docs/sdk-ui-pivot.iabsolutecolumnwidth.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
+++ b/vNext/docs/sdk-ui-pivot.iabsolutecolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.iallmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
+++ b/vNext/docs/sdk-ui-pivot.iattributecolumnlocator.attributelocatoritem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iattributecolumnlocator.html
+++ b/vNext/docs/sdk-ui-pivot.iattributecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.iattributecolumnwidthitem.attributecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.iattributecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iautocolumnwidth.html
+++ b/vNext/docs/sdk-ui-pivot.iautocolumnwidth.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iautocolumnwidth.value.html
+++ b/vNext/docs/sdk-ui-pivot.iautocolumnwidth.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
+++ b/vNext/docs/sdk-ui-pivot.icolumnsizing.columnwidths.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
+++ b/vNext/docs/sdk-ui-pivot.icolumnsizing.defaultwidth.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
+++ b/vNext/docs/sdk-ui-pivot.icolumnsizing.growtofit.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.icolumnsizing.html
+++ b/vNext/docs/sdk-ui-pivot.icolumnsizing.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imeasurecolumnlocator.html
+++ b/vNext/docs/sdk-ui-pivot.imeasurecolumnlocator.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
+++ b/vNext/docs/sdk-ui-pivot.imeasurecolumnlocator.measurelocatoritem.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.imeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.imeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imenu.aggregations.html
+++ b/vNext/docs/sdk-ui-pivot.imenu.aggregations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
+++ b/vNext/docs/sdk-ui-pivot.imenu.aggregationssubmenu.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imenu.aggregationtypes.html
+++ b/vNext/docs/sdk-ui-pivot.imenu.aggregationtypes.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.imenu.html
+++ b/vNext/docs/sdk-ui-pivot.imenu.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.config.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.execconfig.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.execconfig.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.oncolumnresized.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebaseprops.pagesize.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.columns.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.measures.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.rows.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottablebucketprops.totals.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableconfig.columnsizing.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableconfig.grouprows.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableconfig.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableconfig.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableconfig.maxheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableconfig.menu.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableconfig.menu.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableconfig.separators.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableconfig.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableprops.backend.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableprops.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ipivottableprops.workspace.html
+++ b/vNext/docs/sdk-ui-pivot.ipivottableprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
+++ b/vNext/docs/sdk-ui-pivot.isabsolutecolumnwidth.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.isallmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.isattributecolumnlocator.html
+++ b/vNext/docs/sdk-ui-pivot.isattributecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.isattributecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
+++ b/vNext/docs/sdk-ui-pivot.ismeasurecolumnlocator.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.ismeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.isweakmeasurecolumnwidthitem.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
+++ b/vNext/docs/sdk-ui-pivot.iweakmeasurecolumnwidthitem.measurecolumnwidthitem.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.newattributecolumnlocator.html
+++ b/vNext/docs/sdk-ui-pivot.newattributecolumnlocator.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
+++ b/vNext/docs/sdk-ui-pivot.newwidthforallcolumnsformeasure.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
+++ b/vNext/docs/sdk-ui-pivot.newwidthforallmeasurecolumns.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.newwidthforattributecolumn.html
+++ b/vNext/docs/sdk-ui-pivot.newwidthforattributecolumn.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
+++ b/vNext/docs/sdk-ui-pivot.newwidthforselectedcolumns.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.pivottable.html
+++ b/vNext/docs/sdk-ui-pivot.pivottable.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
+++ b/vNext/docs/sdk-ui-pivot.pivottablemenuforcapabilities.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.html
+++ b/vNext/docs/sdk-ui-theme-provider.html
@@ -114,7 +114,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemecontextproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemecontextproviderprops.theme.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemecontextproviderprops.themeisloading.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.enablecomplementarypalette.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.modifier.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.theme.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
+++ b/vNext/docs/sdk-ui-theme-provider.ithemeproviderprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.themecontextprovider.html
+++ b/vNext/docs/sdk-ui-theme-provider.themecontextprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.thememodifier.html
+++ b/vNext/docs/sdk-ui-theme-provider.thememodifier.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.themeprovider.html
+++ b/vNext/docs/sdk-ui-theme-provider.themeprovider.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.usetheme.html
+++ b/vNext/docs/sdk-ui-theme-provider.usetheme.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.usethemeisloading.html
+++ b/vNext/docs/sdk-ui-theme-provider.usethemeisloading.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-theme-provider.withtheme.html
+++ b/vNext/docs/sdk-ui-theme-provider.withtheme.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
+++ b/vNext/docs/sdk-ui-vis-commons.fixemptyheaderitems.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-vis-commons.html
+++ b/vNext/docs/sdk-ui-vis-commons.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-vis-commons.icolormapping.color.html
+++ b/vNext/docs/sdk-ui-vis-commons.icolormapping.color.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-vis-commons.icolormapping.html
+++ b/vNext/docs/sdk-ui-vis-commons.icolormapping.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui-vis-commons.icolormapping.predicate.html
+++ b/vNext/docs/sdk-ui-vis-commons.icolormapping.predicate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.anyarrayof.html
+++ b/vNext/docs/sdk-ui.anyarrayof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.anymeasure.html
+++ b/vNext/docs/sdk-ui.anymeasure.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.anyplaceholder.html
+++ b/vNext/docs/sdk-ui.anyplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.anyplaceholderof.html
+++ b/vNext/docs/sdk-ui.anyplaceholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.arrayof.html
+++ b/vNext/docs/sdk-ui.arrayof.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributefilterorplaceholder.html
+++ b/vNext/docs/sdk-ui.attributefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributefiltersorplaceholders.html
+++ b/vNext/docs/sdk-ui.attributefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributeitemnamematch.html
+++ b/vNext/docs/sdk-ui.attributeitemnamematch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributemeasureorplaceholder.html
+++ b/vNext/docs/sdk-ui.attributemeasureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributeorplaceholder.html
+++ b/vNext/docs/sdk-ui.attributeorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributesmeasuresorplaceholders.html
+++ b/vNext/docs/sdk-ui.attributesmeasuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.attributesorplaceholders.html
+++ b/vNext/docs/sdk-ui.attributesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.backendprovider.html
+++ b/vNext/docs/sdk-ui.backendprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.badrequestsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.badrequestsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.badrequestsdkerror.html
+++ b/vNext/docs/sdk-ui.badrequestsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cancelledsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.cancelledsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cancelledsdkerror.html
+++ b/vNext/docs/sdk-ui.cancelledsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper._constructor_.html
+++ b/vNext/docs/sdk-ui.cataloghelper._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.attribute.html
+++ b/vNext/docs/sdk-ui.cataloghelper.attribute.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.attributedisplayform.html
+++ b/vNext/docs/sdk-ui.cataloghelper.attributedisplayform.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.attributedisplayformtags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.attributes.html
+++ b/vNext/docs/sdk-ui.cataloghelper.attributes.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.attributetags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.attributetags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedataset.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedataset.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedatasetattribute.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedatasetattribute.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedatasetattributetags.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedatasetdisplayform.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedatasetdisplayformtags.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedatasets.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.datedatasettags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.datedatasettags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.html
+++ b/vNext/docs/sdk-ui.cataloghelper.html
@@ -122,7 +122,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.measure.html
+++ b/vNext/docs/sdk-ui.cataloghelper.measure.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.measures.html
+++ b/vNext/docs/sdk-ui.cataloghelper.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.measuretags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.measuretags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.visualization.html
+++ b/vNext/docs/sdk-ui.cataloghelper.visualization.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.visualizations.html
+++ b/vNext/docs/sdk-ui.cataloghelper.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.cataloghelper.visualizationtags.html
+++ b/vNext/docs/sdk-ui.cataloghelper.visualizationtags.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.chartelementtype.html
+++ b/vNext/docs/sdk-ui.chartelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.charttype.html
+++ b/vNext/docs/sdk-ui.charttype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.composedfromidentifier.html
+++ b/vNext/docs/sdk-ui.composedfromidentifier.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.composedfromuri.html
+++ b/vNext/docs/sdk-ui.composedfromuri.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.composedplaceholderresolutioncontext.html
+++ b/vNext/docs/sdk-ui.composedplaceholderresolutioncontext.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.converterror.html
+++ b/vNext/docs/sdk-ui.converterror.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.createnumberjsformatter.html
+++ b/vNext/docs/sdk-ui.createnumberjsformatter.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataaccessconfig.html
+++ b/vNext/docs/sdk-ui.dataaccessconfig.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datapoint.html
+++ b/vNext/docs/sdk-ui.datapoint.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datapointcoordinates.html
+++ b/vNext/docs/sdk-ui.datapointcoordinates.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataseriesdescriptor.html
+++ b/vNext/docs/sdk-ui.dataseriesdescriptor.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataseriesdescriptormethods.html
+++ b/vNext/docs/sdk-ui.dataseriesdescriptormethods.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataseriesheaders.html
+++ b/vNext/docs/sdk-ui.dataseriesheaders.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataseriesid.html
+++ b/vNext/docs/sdk-ui.dataseriesid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataslicedescriptor.html
+++ b/vNext/docs/sdk-ui.dataslicedescriptor.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataslicedescriptormethods.html
+++ b/vNext/docs/sdk-ui.dataslicedescriptormethods.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datasliceheaders.html
+++ b/vNext/docs/sdk-ui.datasliceheaders.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datasliceid.html
+++ b/vNext/docs/sdk-ui.datasliceid.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.datatoolargetocomputesdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datatoolargetocomputesdkerror.html
+++ b/vNext/docs/sdk-ui.datatoolargetocomputesdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.datatoolargetodisplaysdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.datatoolargetodisplaysdkerror.html
+++ b/vNext/docs/sdk-ui.datatoolargetodisplaysdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade._constructor_.html
+++ b/vNext/docs/sdk-ui.dataviewfacade._constructor_.html
@@ -28,7 +28,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.data.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.data.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.dataview.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.definition.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.definition.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.fingerprint.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.fingerprint.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.for.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.for.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.forresult.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.forresult.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.html
@@ -111,7 +111,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.result.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.result.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewfacade.warnings.html
+++ b/vNext/docs/sdk-ui.dataviewfacade.warnings.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dataviewwindow.html
+++ b/vNext/docs/sdk-ui.dataviewwindow.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.defaultcolorpalette.html
+++ b/vNext/docs/sdk-ui.defaultcolorpalette.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.defaultdataaccessconfig.html
+++ b/vNext/docs/sdk-ui.defaultdataaccessconfig.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.defaulterrorhandler.html
+++ b/vNext/docs/sdk-ui.defaulterrorhandler.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.defaultlocale.html
+++ b/vNext/docs/sdk-ui.defaultlocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.drilleventintersectionelementheader.html
+++ b/vNext/docs/sdk-ui.drilleventintersectionelementheader.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dynamicscriptloadsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.dynamicscriptloadsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.dynamicscriptloadsdkerror.html
+++ b/vNext/docs/sdk-ui.dynamicscriptloadsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.errorcodes.html
+++ b/vNext/docs/sdk-ui.errorcodes.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.errorcomponent.defaultprops.html
+++ b/vNext/docs/sdk-ui.errorcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.errorcomponent.html
+++ b/vNext/docs/sdk-ui.errorcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.errorcomponent.render.html
+++ b/vNext/docs/sdk-ui.errorcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.execute.html
+++ b/vNext/docs/sdk-ui.execute.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.executeinsight.html
+++ b/vNext/docs/sdk-ui.executeinsight.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.explicitdrill.html
+++ b/vNext/docs/sdk-ui.explicitdrill.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.filterormultivalueplaceholder.html
+++ b/vNext/docs/sdk-ui.filterormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.filterorplaceholder.html
+++ b/vNext/docs/sdk-ui.filterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.filtersorplaceholders.html
+++ b/vNext/docs/sdk-ui.filtersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.flatten.html
+++ b/vNext/docs/sdk-ui.flatten.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.geolocationmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.geolocationmissingsdkerror.html
+++ b/vNext/docs/sdk-ui.geolocationmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.geotokenmissingsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.geotokenmissingsdkerror.html
+++ b/vNext/docs/sdk-ui.geotokenmissingsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror._constructor_.html
@@ -30,7 +30,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror.cause.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror.cause.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror.getcause.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror.getcause.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror.geterrorcode.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror.getmessage.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror.getmessage.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror.html
@@ -106,7 +106,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.gooddatasdkerror.setype.html
+++ b/vNext/docs/sdk-ui.gooddatasdkerror.setype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.headerpredicates.html
+++ b/vNext/docs/sdk-ui.headerpredicates.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.headertranslator.html
+++ b/vNext/docs/sdk-ui.headertranslator.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.headlineelementtype.html
+++ b/vNext/docs/sdk-ui.headlineelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.headlinetype.html
+++ b/vNext/docs/sdk-ui.headlinetype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.html
+++ b/vNext/docs/sdk-ui.html
@@ -348,7 +348,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iattritem.defaultdisplayform.html
+++ b/vNext/docs/sdk-ui.iattritem.defaultdisplayform.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iattritem.displayforms.html
+++ b/vNext/docs/sdk-ui.iattritem.displayforms.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iattritem.html
+++ b/vNext/docs/sdk-ui.iattritem.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iattritem.identifier.html
+++ b/vNext/docs/sdk-ui.iattritem.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iattritem.tags.html
+++ b/vNext/docs/sdk-ui.iattritem.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iattrs.html
+++ b/vNext/docs/sdk-ui.iattrs.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ibackendproviderprops.backend.html
+++ b/vNext/docs/sdk-ui.ibackendproviderprops.backend.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ibackendproviderprops.html
+++ b/vNext/docs/sdk-ui.ibackendproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icatalog.attributes.html
+++ b/vNext/docs/sdk-ui.icatalog.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icatalog.datedatasets.html
+++ b/vNext/docs/sdk-ui.icatalog.datedatasets.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icatalog.html
+++ b/vNext/docs/sdk-ui.icatalog.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icatalog.measures.html
+++ b/vNext/docs/sdk-ui.icatalog.measures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icatalog.visualizations.html
+++ b/vNext/docs/sdk-ui.icatalog.visualizations.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icomposedplaceholder.computevalue.html
+++ b/vNext/docs/sdk-ui.icomposedplaceholder.computevalue.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icomposedplaceholder.html
+++ b/vNext/docs/sdk-ui.icomposedplaceholder.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icomposedplaceholder.placeholders.html
+++ b/vNext/docs/sdk-ui.icomposedplaceholder.placeholders.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icomposedplaceholder.type.html
+++ b/vNext/docs/sdk-ui.icomposedplaceholder.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.icomposedplaceholder.use.html
+++ b/vNext/docs/sdk-ui.icomposedplaceholder.use.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataaccessmethods.html
+++ b/vNext/docs/sdk-ui.idataaccessmethods.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataaccessmethods.series.html
+++ b/vNext/docs/sdk-ui.idataaccessmethods.series.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataaccessmethods.slices.html
+++ b/vNext/docs/sdk-ui.idataaccessmethods.slices.html
@@ -21,7 +21,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseries.datapoints.html
+++ b/vNext/docs/sdk-ui.idataseries.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseries.descriptor.html
+++ b/vNext/docs/sdk-ui.idataseries.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseries.html
+++ b/vNext/docs/sdk-ui.idataseries.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseries.id.html
+++ b/vNext/docs/sdk-ui.idataseries.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseries.rawdata.html
+++ b/vNext/docs/sdk-ui.idataseries.rawdata.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.allformeasure.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.allformeasure.html
@@ -31,7 +31,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.count.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.firstformeasure.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.firstformeasure.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.frommeasures.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.frommeasures.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.frommeasuresdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.html
@@ -100,7 +100,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.scopingattributes.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.scopingattributes.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.scopingattributesdef.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataseriescollection.toarray.html
+++ b/vNext/docs/sdk-ui.idataseriescollection.toarray.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataset.attributes.html
+++ b/vNext/docs/sdk-ui.idataset.attributes.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataset.html
+++ b/vNext/docs/sdk-ui.idataset.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataset.identifier.html
+++ b/vNext/docs/sdk-ui.idataset.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataset.tags.html
+++ b/vNext/docs/sdk-ui.idataset.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslice.datapoints.html
+++ b/vNext/docs/sdk-ui.idataslice.datapoints.html
@@ -25,7 +25,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslice.descriptor.html
+++ b/vNext/docs/sdk-ui.idataslice.descriptor.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslice.html
+++ b/vNext/docs/sdk-ui.idataslice.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslice.id.html
+++ b/vNext/docs/sdk-ui.idataslice.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslice.rawdata.html
+++ b/vNext/docs/sdk-ui.idataslice.rawdata.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslicecollection.count.html
+++ b/vNext/docs/sdk-ui.idataslicecollection.count.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslicecollection.descriptors.html
+++ b/vNext/docs/sdk-ui.idataslicecollection.descriptors.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslicecollection.html
+++ b/vNext/docs/sdk-ui.idataslicecollection.html
@@ -96,7 +96,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idataslicecollection.toarray.html
+++ b/vNext/docs/sdk-ui.idataslicecollection.toarray.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idatavisualizationprops.execution.html
+++ b/vNext/docs/sdk-ui.idatavisualizationprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idatavisualizationprops.html
+++ b/vNext/docs/sdk-ui.idatavisualizationprops.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.identifiermatch.html
+++ b/vNext/docs/sdk-ui.identifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idisplayforms.html
+++ b/vNext/docs/sdk-ui.idisplayforms.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillableitem.html
+++ b/vNext/docs/sdk-ui.idrillableitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillableitemidentifier.html
+++ b/vNext/docs/sdk-ui.idrillableitemidentifier.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillableitemidentifier.identifier.html
+++ b/vNext/docs/sdk-ui.idrillableitemidentifier.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillableitemuri.html
+++ b/vNext/docs/sdk-ui.idrillableitemuri.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillableitemuri.uri.html
+++ b/vNext/docs/sdk-ui.idrillableitemuri.uri.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillconfig.dataview.html
+++ b/vNext/docs/sdk-ui.idrillconfig.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillconfig.html
+++ b/vNext/docs/sdk-ui.idrillconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillconfig.ondrill.html
+++ b/vNext/docs/sdk-ui.idrillconfig.ondrill.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillevent.dataview.html
+++ b/vNext/docs/sdk-ui.idrillevent.dataview.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillevent.drillcontext.html
+++ b/vNext/docs/sdk-ui.idrillevent.drillcontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillevent.html
+++ b/vNext/docs/sdk-ui.idrillevent.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcallback.html
+++ b/vNext/docs/sdk-ui.idrilleventcallback.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.columnindex.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.element.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.intersection.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.points.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.row.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.rowindex.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.type.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.value.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.x.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.y.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontext.z.html
+++ b/vNext/docs/sdk-ui.idrilleventcontext.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextgroup.element.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextgroup.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextgroup.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextgroup.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextgroup.points.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextgroup.points.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextgroup.type.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextgroup.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextheadline.element.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextheadline.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextheadline.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextheadline.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextheadline.intersection.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextheadline.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextheadline.type.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextheadline.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextheadline.value.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextheadline.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.element.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.elementcharttype.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.intersection.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.type.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.value.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.x.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.y.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextpoint.z.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextpoint.z.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.columnindex.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.columnindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.element.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.intersection.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.row.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.row.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.rowindex.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.rowindex.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontexttable.type.html
+++ b/vNext/docs/sdk-ui.idrilleventcontexttable.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextxirr.element.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextxirr.element.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextxirr.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextxirr.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextxirr.intersection.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextxirr.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextxirr.type.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextxirr.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventcontextxirr.value.html
+++ b/vNext/docs/sdk-ui.idrilleventcontextxirr.value.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventintersectionelement.header.html
+++ b/vNext/docs/sdk-ui.idrilleventintersectionelement.header.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrilleventintersectionelement.html
+++ b/vNext/docs/sdk-ui.idrilleventintersectionelement.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillintersectionattributeitem.html
+++ b/vNext/docs/sdk-ui.idrillintersectionattributeitem.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillpoint.html
+++ b/vNext/docs/sdk-ui.idrillpoint.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillpoint.intersection.html
+++ b/vNext/docs/sdk-ui.idrillpoint.intersection.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillpoint.type.html
+++ b/vNext/docs/sdk-ui.idrillpoint.type.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillpoint.x.html
+++ b/vNext/docs/sdk-ui.idrillpoint.x.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.idrillpoint.y.html
+++ b/vNext/docs/sdk-ui.idrillpoint.y.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrordescriptors.html
+++ b/vNext/docs/sdk-ui.ierrordescriptors.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.classname.html
+++ b/vNext/docs/sdk-ui.ierrorprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.clientheight.html
+++ b/vNext/docs/sdk-ui.ierrorprops.clientheight.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.code.html
+++ b/vNext/docs/sdk-ui.ierrorprops.code.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.description.html
+++ b/vNext/docs/sdk-ui.ierrorprops.description.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.height.html
+++ b/vNext/docs/sdk-ui.ierrorprops.height.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.html
+++ b/vNext/docs/sdk-ui.ierrorprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.icon.html
+++ b/vNext/docs/sdk-ui.ierrorprops.icon.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.message.html
+++ b/vNext/docs/sdk-ui.ierrorprops.message.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.style.html
+++ b/vNext/docs/sdk-ui.ierrorprops.style.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ierrorprops.width.html
+++ b/vNext/docs/sdk-ui.ierrorprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteerrorcomponent.html
+++ b/vNext/docs/sdk-ui.iexecuteerrorcomponent.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
+++ b/vNext/docs/sdk-ui.iexecuteerrorcomponentprops.error.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteerrorcomponentprops.html
+++ b/vNext/docs/sdk-ui.iexecuteerrorcomponentprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.backend.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.children.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.children.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.componentname.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.dateformat.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.dimensions.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.errorcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.exporttitle.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.filters.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.html
@@ -101,7 +101,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.insight.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.insight.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.loadingcomponent.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.loadonmount.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.sorts.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.window.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.window.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteinsightprops.workspace.html
+++ b/vNext/docs/sdk-ui.iexecuteinsightprops.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteloadingcomponent.html
+++ b/vNext/docs/sdk-ui.iexecuteloadingcomponent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.backend.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.children.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.componentname.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.componentname.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.errorcomponent.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.errorcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.exporttitle.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.filters.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.html
@@ -99,7 +99,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.loadingcomponent.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.loadonmount.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.placeholdersresolutioncontext.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.seriesby.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.seriesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.slicesby.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.slicesby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.sortby.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.sortby.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.totals.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.totals.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.window.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecuteprops.workspace.html
+++ b/vNext/docs/sdk-ui.iexecuteprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.componentname.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.filters.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.seriesby.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.slicesby.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.sortby.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexecutionconfiguration.totals.html
+++ b/vNext/docs/sdk-ui.iexecutionconfiguration.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iexportfunction.html
+++ b/vNext/docs/sdk-ui.iexportfunction.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iextendedexportconfig.html
+++ b/vNext/docs/sdk-ui.iextendedexportconfig.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
+++ b/vNext/docs/sdk-ui.iextendedexportconfig.includefiltercontext.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iheaderpredicate.html
+++ b/vNext/docs/sdk-ui.iheaderpredicate.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iheaderpredicatecontext.dv.html
+++ b/vNext/docs/sdk-ui.iheaderpredicatecontext.dv.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iheaderpredicatecontext.html
+++ b/vNext/docs/sdk-ui.iheaderpredicatecontext.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ihighchartscategoriestree.html
+++ b/vNext/docs/sdk-ui.ihighchartscategoriestree.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ihighchartscategoriestree.tick.html
+++ b/vNext/docs/sdk-ui.ihighchartscategoriestree.tick.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ihighchartsparenttick.html
+++ b/vNext/docs/sdk-ui.ihighchartsparenttick.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ihighchartsparenttick.label.html
+++ b/vNext/docs/sdk-ui.ihighchartsparenttick.label.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ihighchartsparenttick.leaves.html
+++ b/vNext/docs/sdk-ui.ihighchartsparenttick.leaves.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ihighchartsparenttick.startat.html
+++ b/vNext/docs/sdk-ui.ihighchartsparenttick.startat.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iidentifierwithtags.html
+++ b/vNext/docs/sdk-ui.iidentifierwithtags.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iidentifierwithtags.identifier.html
+++ b/vNext/docs/sdk-ui.iidentifierwithtags.identifier.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iidentifierwithtags.tags.html
+++ b/vNext/docs/sdk-ui.iidentifierwithtags.tags.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.backend.html
+++ b/vNext/docs/sdk-ui.ikpiprops.backend.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.errorcomponent.html
+++ b/vNext/docs/sdk-ui.ikpiprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.filters.html
+++ b/vNext/docs/sdk-ui.ikpiprops.filters.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.html
+++ b/vNext/docs/sdk-ui.ikpiprops.html
@@ -92,7 +92,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.loadingcomponent.html
+++ b/vNext/docs/sdk-ui.ikpiprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.locale.html
+++ b/vNext/docs/sdk-ui.ikpiprops.locale.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.measure.html
+++ b/vNext/docs/sdk-ui.ikpiprops.measure.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.separators.html
+++ b/vNext/docs/sdk-ui.ikpiprops.separators.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ikpiprops.workspace.html
+++ b/vNext/docs/sdk-ui.ikpiprops.workspace.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.classname.html
+++ b/vNext/docs/sdk-ui.iloadingprops.classname.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.color.html
+++ b/vNext/docs/sdk-ui.iloadingprops.color.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.height.html
+++ b/vNext/docs/sdk-ui.iloadingprops.height.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.html
+++ b/vNext/docs/sdk-ui.iloadingprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.imageheight.html
+++ b/vNext/docs/sdk-ui.iloadingprops.imageheight.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.imagewidth.html
+++ b/vNext/docs/sdk-ui.iloadingprops.imagewidth.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.inline.html
+++ b/vNext/docs/sdk-ui.iloadingprops.inline.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.speed.html
+++ b/vNext/docs/sdk-ui.iloadingprops.speed.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingprops.width.html
+++ b/vNext/docs/sdk-ui.iloadingprops.width.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingstate.html
+++ b/vNext/docs/sdk-ui.iloadingstate.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iloadingstate.isloading.html
+++ b/vNext/docs/sdk-ui.iloadingstate.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ilocale.html
+++ b/vNext/docs/sdk-ui.ilocale.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.imappingheader.html
+++ b/vNext/docs/sdk-ui.imappingheader.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholder.html
+++ b/vNext/docs/sdk-ui.iplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholderoptions.html
+++ b/vNext/docs/sdk-ui.iplaceholderoptions.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholderoptions.id.html
+++ b/vNext/docs/sdk-ui.iplaceholderoptions.id.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholderoptions.validate.html
+++ b/vNext/docs/sdk-ui.iplaceholderoptions.validate.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholdersproviderprops.children.html
+++ b/vNext/docs/sdk-ui.iplaceholdersproviderprops.children.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholdersproviderprops.html
+++ b/vNext/docs/sdk-ui.iplaceholdersproviderprops.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
+++ b/vNext/docs/sdk-ui.iplaceholdersproviderprops.initialvalues.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.children.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.children.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.errorcomponent.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.execution.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.execution.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.exporttitle.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.loadingcomponent.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.loadonmount.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.loadonmount.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.irawexecuteprops.window.html
+++ b/vNext/docs/sdk-ui.irawexecuteprops.window.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isanyplaceholder.html
+++ b/vNext/docs/sdk-ui.isanyplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isbadrequest.html
+++ b/vNext/docs/sdk-ui.isbadrequest.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iscancelledsdkerror.html
+++ b/vNext/docs/sdk-ui.iscancelledsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iscomposedplaceholder.html
+++ b/vNext/docs/sdk-ui.iscomposedplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdatatoolargetocompute.html
+++ b/vNext/docs/sdk-ui.isdatatoolargetocompute.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdatatoolargetodisplay.html
+++ b/vNext/docs/sdk-ui.isdatatoolargetodisplay.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdrillableitem.html
+++ b/vNext/docs/sdk-ui.isdrillableitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdrillableitemidentifier.html
+++ b/vNext/docs/sdk-ui.isdrillableitemidentifier.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdrillableitemuri.html
+++ b/vNext/docs/sdk-ui.isdrillableitemuri.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdrillintersectionattributeitem.html
+++ b/vNext/docs/sdk-ui.isdrillintersectionattributeitem.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isdynamicscriptloadsdkerror.html
+++ b/vNext/docs/sdk-ui.isdynamicscriptloadsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isexplicitdrill.html
+++ b/vNext/docs/sdk-ui.isexplicitdrill.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isgeolocationmissing.html
+++ b/vNext/docs/sdk-ui.isgeolocationmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isgeotokenmissing.html
+++ b/vNext/docs/sdk-ui.isgeotokenmissing.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isgooddatasdkerror.html
+++ b/vNext/docs/sdk-ui.isgooddatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isheaderpredicate.html
+++ b/vNext/docs/sdk-ui.isheaderpredicate.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isnegativevalues.html
+++ b/vNext/docs/sdk-ui.isnegativevalues.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isnodatasdkerror.html
+++ b/vNext/docs/sdk-ui.isnodatasdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isnotfound.html
+++ b/vNext/docs/sdk-ui.isnotfound.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isplaceholder.html
+++ b/vNext/docs/sdk-ui.isplaceholder.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isprotectedreport.html
+++ b/vNext/docs/sdk-ui.isprotectedreport.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isunauthorized.html
+++ b/vNext/docs/sdk-ui.isunauthorized.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.isunknownsdkerror.html
+++ b/vNext/docs/sdk-ui.isunknownsdkerror.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationcontextproviderprops.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationcontextproviderprops.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translations.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translations.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translationscustomizationisloading.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationcontextproviderprops.translationscustomizationisloading.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.backend.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.customize.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.customize.html
@@ -34,7 +34,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.html
@@ -98,7 +98,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.render.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.render.html
@@ -33,7 +33,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.translations.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.translations.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.workspace.html
+++ b/vNext/docs/sdk-ui.itranslationscustomizationproviderprops.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iusecomposedplaceholderhook.html
+++ b/vNext/docs/sdk-ui.iusecomposedplaceholderhook.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.backend.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.componentname.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.componentname.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.filters.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.placeholdersresolutioncontext.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.seriesby.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.seriesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.slicesby.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.slicesby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.sortby.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.sortby.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.totals.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.totals.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutionconfig.workspace.html
+++ b/vNext/docs/sdk-ui.iuseexecutionconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
+++ b/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
+++ b/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.execution.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.html
+++ b/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
+++ b/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
+++ b/vNext/docs/sdk-ui.iuseexecutiondataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.backend.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.dateformat.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.dimensions.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.filters.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.insight.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.sorts.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.window.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.window.html
@@ -22,7 +22,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
+++ b/vNext/docs/sdk-ui.iuseinsightdataviewconfig.workspace.html
@@ -23,7 +23,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iusepagedresourceresult.html
+++ b/vNext/docs/sdk-ui.iusepagedresourceresult.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iusepagedresourceresult.isloading.html
+++ b/vNext/docs/sdk-ui.iusepagedresourceresult.isloading.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iusepagedresourcestate.html
+++ b/vNext/docs/sdk-ui.iusepagedresourcestate.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iusepagedresourcestate.items.html
+++ b/vNext/docs/sdk-ui.iusepagedresourcestate.items.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
+++ b/vNext/docs/sdk-ui.iusepagedresourcestate.totalitemscount.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iuseplaceholderhook.html
+++ b/vNext/docs/sdk-ui.iuseplaceholderhook.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationcallbacks.html
+++ b/vNext/docs/sdk-ui.ivisualizationcallbacks.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
+++ b/vNext/docs/sdk-ui.ivisualizationcallbacks.ondrill.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationcallbacks.onerror.html
+++ b/vNext/docs/sdk-ui.ivisualizationcallbacks.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
+++ b/vNext/docs/sdk-ui.ivisualizationcallbacks.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
+++ b/vNext/docs/sdk-ui.ivisualizationcallbacks.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationprops.drillableitems.html
+++ b/vNext/docs/sdk-ui.ivisualizationprops.drillableitems.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationprops.errorcomponent.html
+++ b/vNext/docs/sdk-ui.ivisualizationprops.errorcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationprops.exporttitle.html
+++ b/vNext/docs/sdk-ui.ivisualizationprops.exporttitle.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationprops.html
+++ b/vNext/docs/sdk-ui.ivisualizationprops.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
+++ b/vNext/docs/sdk-ui.ivisualizationprops.loadingcomponent.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.ivisualizationprops.locale.html
+++ b/vNext/docs/sdk-ui.ivisualizationprops.locale.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iwithloadingevents.html
+++ b/vNext/docs/sdk-ui.iwithloadingevents.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iwithloadingevents.onerror.html
+++ b/vNext/docs/sdk-ui.iwithloadingevents.onerror.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iwithloadingevents.onexportready.html
+++ b/vNext/docs/sdk-ui.iwithloadingevents.onexportready.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
+++ b/vNext/docs/sdk-ui.iwithloadingevents.onloadingchanged.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
+++ b/vNext/docs/sdk-ui.iwithloadingevents.onloadingfinish.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iwithloadingevents.onloadingstart.html
+++ b/vNext/docs/sdk-ui.iwithloadingevents.onloadingstart.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iworkspaceproviderprops.html
+++ b/vNext/docs/sdk-ui.iworkspaceproviderprops.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.iworkspaceproviderprops.workspace.html
+++ b/vNext/docs/sdk-ui.iworkspaceproviderprops.workspace.html
@@ -19,7 +19,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.kpi.html
+++ b/vNext/docs/sdk-ui.kpi.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.loadingcomponent.defaultprops.html
+++ b/vNext/docs/sdk-ui.loadingcomponent.defaultprops.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.loadingcomponent.html
+++ b/vNext/docs/sdk-ui.loadingcomponent.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.loadingcomponent.render.html
+++ b/vNext/docs/sdk-ui.loadingcomponent.render.html
@@ -20,7 +20,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.localidentifiermatch.html
+++ b/vNext/docs/sdk-ui.localidentifiermatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.measureof.html
+++ b/vNext/docs/sdk-ui.measureof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.measureorplaceholder.html
+++ b/vNext/docs/sdk-ui.measureorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.measuresorplaceholders.html
+++ b/vNext/docs/sdk-ui.measuresorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.negativevaluessdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.negativevaluessdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.negativevaluessdkerror.html
+++ b/vNext/docs/sdk-ui.negativevaluessdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.newcomposedplaceholder.html
+++ b/vNext/docs/sdk-ui.newcomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.newerrormapping.html
+++ b/vNext/docs/sdk-ui.newerrormapping.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.newplaceholder.html
+++ b/vNext/docs/sdk-ui.newplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.nodatasdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.nodatasdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.nodatasdkerror.html
+++ b/vNext/docs/sdk-ui.nodatasdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.notfoundsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.notfoundsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.notfoundsdkerror.html
+++ b/vNext/docs/sdk-ui.notfoundsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.nullablefilterorplaceholder.html
+++ b/vNext/docs/sdk-ui.nullablefilterorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.nullablefiltersorplaceholders.html
+++ b/vNext/docs/sdk-ui.nullablefiltersorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.objmatch.html
+++ b/vNext/docs/sdk-ui.objmatch.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.objrefmatch.html
+++ b/vNext/docs/sdk-ui.objrefmatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.onerror.html
+++ b/vNext/docs/sdk-ui.onerror.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.onexportready.html
+++ b/vNext/docs/sdk-ui.onexportready.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.onfireddrillevent.html
+++ b/vNext/docs/sdk-ui.onfireddrillevent.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.onloadingchanged.html
+++ b/vNext/docs/sdk-ui.onloadingchanged.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.pickcorrectinsightwording.html
+++ b/vNext/docs/sdk-ui.pickcorrectinsightwording.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.pickcorrectmetricwording.html
+++ b/vNext/docs/sdk-ui.pickcorrectmetricwording.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.pickcorrectwording.html
+++ b/vNext/docs/sdk-ui.pickcorrectwording.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.placeholderof.html
+++ b/vNext/docs/sdk-ui.placeholderof.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.placeholderresolvedvalue.html
+++ b/vNext/docs/sdk-ui.placeholderresolvedvalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.placeholdersprovider.html
+++ b/vNext/docs/sdk-ui.placeholdersprovider.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.placeholdersresolvedvalues.html
+++ b/vNext/docs/sdk-ui.placeholdersresolvedvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.placeholdersvalues.html
+++ b/vNext/docs/sdk-ui.placeholdersvalues.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.placeholdervalue.html
+++ b/vNext/docs/sdk-ui.placeholdervalue.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.protectedreportsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.protectedreportsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.protectedreportsdkerror.html
+++ b/vNext/docs/sdk-ui.protectedreportsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.rawexecute.html
+++ b/vNext/docs/sdk-ui.rawexecute.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.removeallinsighttoreporttranslations.html
+++ b/vNext/docs/sdk-ui.removeallinsighttoreporttranslations.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.removeallwordingtranslationswithspecialsuffix.html
+++ b/vNext/docs/sdk-ui.removeallwordingtranslationswithspecialsuffix.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.resolveusecancelablepromiseserror.html
+++ b/vNext/docs/sdk-ui.resolveusecancelablepromiseserror.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.resolveusecancelablepromisesstatus.html
+++ b/vNext/docs/sdk-ui.resolveusecancelablepromisesstatus.html
@@ -95,7 +95,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.sdkerrortype.html
+++ b/vNext/docs/sdk-ui.sdkerrortype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.sortsorplaceholders.html
+++ b/vNext/docs/sdk-ui.sortsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.tableelementtype.html
+++ b/vNext/docs/sdk-ui.tableelementtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.tabletype.html
+++ b/vNext/docs/sdk-ui.tabletype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.totalsorplaceholders.html
+++ b/vNext/docs/sdk-ui.totalsorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.translationscustomizationcontextprovider.html
+++ b/vNext/docs/sdk-ui.translationscustomizationcontextprovider.html
@@ -77,7 +77,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.translationscustomizationprovider.html
+++ b/vNext/docs/sdk-ui.translationscustomizationprovider.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.unauthorizedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
+++ b/vNext/docs/sdk-ui.unauthorizedsdkerror.authenticationflow.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.unauthorizedsdkerror.html
+++ b/vNext/docs/sdk-ui.unauthorizedsdkerror.html
@@ -94,7 +94,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.unexpectedsdkerror._constructor_.html
+++ b/vNext/docs/sdk-ui.unexpectedsdkerror._constructor_.html
@@ -29,7 +29,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.unexpectedsdkerror.html
+++ b/vNext/docs/sdk-ui.unexpectedsdkerror.html
@@ -85,7 +85,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.uniontointersection.html
+++ b/vNext/docs/sdk-ui.uniontointersection.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.urimatch.html
+++ b/vNext/docs/sdk-ui.urimatch.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usebackend.html
+++ b/vNext/docs/sdk-ui.usebackend.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usebackendstrict.html
+++ b/vNext/docs/sdk-ui.usebackendstrict.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromise.html
+++ b/vNext/docs/sdk-ui.usecancelablepromise.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromisecallbacks.html
+++ b/vNext/docs/sdk-ui.usecancelablepromisecallbacks.html
@@ -84,7 +84,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromiseerrorstate.html
+++ b/vNext/docs/sdk-ui.usecancelablepromiseerrorstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromiseloadingstate.html
+++ b/vNext/docs/sdk-ui.usecancelablepromiseloadingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromiseoptions.html
+++ b/vNext/docs/sdk-ui.usecancelablepromiseoptions.html
@@ -81,7 +81,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromisependingstate.html
+++ b/vNext/docs/sdk-ui.usecancelablepromisependingstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromisestate.html
+++ b/vNext/docs/sdk-ui.usecancelablepromisestate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromisestatus.html
+++ b/vNext/docs/sdk-ui.usecancelablepromisestatus.html
@@ -78,7 +78,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecancelablepromisesuccessstate.html
+++ b/vNext/docs/sdk-ui.usecancelablepromisesuccessstate.html
@@ -82,7 +82,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usecomposedplaceholder.html
+++ b/vNext/docs/sdk-ui.usecomposedplaceholder.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usedataexport.html
+++ b/vNext/docs/sdk-ui.usedataexport.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usedataexportcallbacks.html
+++ b/vNext/docs/sdk-ui.usedataexportcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usedataexportstate.html
+++ b/vNext/docs/sdk-ui.usedataexportstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usedataview.html
+++ b/vNext/docs/sdk-ui.usedataview.html
@@ -93,7 +93,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usedataviewcallbacks.html
+++ b/vNext/docs/sdk-ui.usedataviewcallbacks.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usedataviewstate.html
+++ b/vNext/docs/sdk-ui.usedataviewstate.html
@@ -79,7 +79,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useexecution.html
+++ b/vNext/docs/sdk-ui.useexecution.html
@@ -89,7 +89,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useexecutiondataview.html
+++ b/vNext/docs/sdk-ui.useexecutiondataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useinsightdataview.html
+++ b/vNext/docs/sdk-ui.useinsightdataview.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.usepagedresource.html
+++ b/vNext/docs/sdk-ui.usepagedresource.html
@@ -91,7 +91,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useplaceholder.html
+++ b/vNext/docs/sdk-ui.useplaceholder.html
@@ -90,7 +90,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useplaceholders.html
+++ b/vNext/docs/sdk-ui.useplaceholders.html
@@ -86,7 +86,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useresolvevalueswithplaceholders.html
+++ b/vNext/docs/sdk-ui.useresolvevalueswithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useresolvevaluewithplaceholders.html
+++ b/vNext/docs/sdk-ui.useresolvevaluewithplaceholders.html
@@ -87,7 +87,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useworkspace.html
+++ b/vNext/docs/sdk-ui.useworkspace.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.useworkspacestrict.html
+++ b/vNext/docs/sdk-ui.useworkspacestrict.html
@@ -83,7 +83,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.valueformatter.html
+++ b/vNext/docs/sdk-ui.valueformatter.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.valueormultivalueplaceholder.html
+++ b/vNext/docs/sdk-ui.valueormultivalueplaceholder.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.valueorplaceholder.html
+++ b/vNext/docs/sdk-ui.valueorplaceholder.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.valuesorplaceholders.html
+++ b/vNext/docs/sdk-ui.valuesorplaceholders.html
@@ -76,7 +76,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.viselementtype.html
+++ b/vNext/docs/sdk-ui.viselementtype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.vistype.html
+++ b/vNext/docs/sdk-ui.vistype.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.withloadingresult.html
+++ b/vNext/docs/sdk-ui.withloadingresult.html
@@ -80,7 +80,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.withtranslationscustomization.html
+++ b/vNext/docs/sdk-ui.withtranslationscustomization.html
@@ -88,7 +88,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.workspaceprovider.html
+++ b/vNext/docs/sdk-ui.workspaceprovider.html
@@ -75,7 +75,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/docs/sdk-ui.xirrtype.html
+++ b/vNext/docs/sdk-ui.xirrtype.html
@@ -74,7 +74,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/en/help.html
+++ b/vNext/en/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/en/index.html
+++ b/vNext/en/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/en/users.html
+++ b/vNext/en/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/help.html
+++ b/vNext/help.html
@@ -18,7 +18,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/index.html
+++ b/vNext/index.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}

--- a/vNext/users.html
+++ b/vNext/users.html
@@ -12,7 +12,8 @@
               </script><script>
               var search = docsearch({
                 
-                apiKey: '96c60b7fb8c45e6d7598a7e4469d175d',
+                appId: 'WMJ16KLCLT',
+                apiKey: 'e5b1637b413b99533ae0f13f3d9d1417',
                 indexName: 'gooddata',
                 inputSelector: '#search_input_react',
                 algoliaOptions: {"facetFilters":["version:Next","tags:gooddata-ui-apidocs"]}


### PR DESCRIPTION
Follow up to #15, this migrates also the older versions from the legacy DocSearch to the new one.